### PR TITLE
More efficient parsing of valid 36-byte UUIDs

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -38,7 +38,7 @@ trait CommonModule extends ScalaModule with ScalafmtModule {
 }
 
 trait CommonPublishModule extends CommonModule with PublishModule with CrossScalaModule{
-  def publishVersion = "1.0.1"
+  def publishVersion = "1.0.2-SNAPSHOT"
 
   def pomSettings = PomSettings(
     description = artifactName(),

--- a/core/src/com/rallyhealth/weepickle/v1/core/Util.scala
+++ b/core/src/com/rallyhealth/weepickle/v1/core/Util.scala
@@ -1,5 +1,7 @@
 package com.rallyhealth.weepickle.v1.core
 
+import java.util.UUID
+
 object Util {
 
   def parseIntegralNum(s: CharSequence, decIndex: Int, expIndex: Int): Long = {
@@ -72,5 +74,69 @@ object Util {
     }
 
     inverseSum * inverseSign
+  }
+
+  def parseUUID(name: CharSequence): UUID = {
+    val ns = nibbles
+    var msb, lsb = 0L
+    if (name.length == 36 && {
+      val ch1: Long = name.charAt(8)
+      val ch2: Long = name.charAt(13)
+      val ch3: Long = name.charAt(18)
+      val ch4: Long = name.charAt(23)
+      (ch1 << 48 | ch2 << 32 | ch3 << 16 | ch4) == 0x2D002D002D002DL
+    } && {
+      val msb1 = parse4Nibbles(name, ns, 0)
+      val msb2 = parse4Nibbles(name, ns, 4)
+      val msb3 = parse4Nibbles(name, ns, 9)
+      val msb4 = parse4Nibbles(name, ns, 14)
+      msb = msb1 << 48 | msb2 << 32 | msb3 << 16 | msb4
+      (msb1 | msb2 | msb3 | msb4) >= 0
+    } && {
+      val lsb1 = parse4Nibbles(name, ns, 19)
+      val lsb2 = parse4Nibbles(name, ns, 24)
+      val lsb3 = parse4Nibbles(name, ns, 28)
+      val lsb4 = parse4Nibbles(name, ns, 32)
+      lsb = lsb1 << 48 | lsb2 << 32 | lsb3 << 16 | lsb4
+      (lsb1 | lsb2 | lsb3 | lsb4) >= 0
+    }) new UUID(msb, lsb)
+    else UUID.fromString(name.toString)
+  }
+
+  private[this] def parse4Nibbles(name: CharSequence, ns: Array[Byte], pos: Int): Long = {
+    val ch1 = name.charAt(pos)
+    val ch2 = name.charAt(pos + 1)
+    val ch3 = name.charAt(pos + 2)
+    val ch4 = name.charAt(pos + 3)
+    if ((ch1 | ch2 | ch3 | ch4) > 0xFF) -1
+    else ns(ch1) << 12 | ns(ch2) << 8 | ns(ch3) << 4 | ns(ch4)
+  }
+
+  private[this] val nibbles: Array[Byte] = {
+    val ns = new Array[Byte](256)
+    java.util.Arrays.fill(ns, -1: Byte)
+    ns('0') = 0
+    ns('1') = 1
+    ns('2') = 2
+    ns('3') = 3
+    ns('4') = 4
+    ns('5') = 5
+    ns('6') = 6
+    ns('7') = 7
+    ns('8') = 8
+    ns('9') = 9
+    ns('A') = 10
+    ns('B') = 11
+    ns('C') = 12
+    ns('D') = 13
+    ns('E') = 14
+    ns('F') = 15
+    ns('a') = 10
+    ns('b') = 11
+    ns('c') = 12
+    ns('d') = 13
+    ns('e') = 14
+    ns('f') = 15
+    ns
   }
 }

--- a/implicits/src/com/rallyhealth/weepickle/v1/implicits/DefaultTos.scala
+++ b/implicits/src/com/rallyhealth/weepickle/v1/implicits/DefaultTos.scala
@@ -126,7 +126,7 @@ trait DefaultTos extends com.rallyhealth.weepickle.v1.core.Types with Generated 
       Util.parseIntegralNum(cs, decIndex, expIndex).toChar
     }
   }
-  implicit val ToUUID: To[UUID] = new MapStringTo(s => UUID.fromString(s.toString))
+  implicit val ToUUID: To[UUID] = new MapStringTo(s => Util.parseUUID(s))
   implicit val ToLong: To[Long] = new NumericTo[Long] {
     override def expectedMsg = "expected number"
     override def visitString(d: CharSequence): Long = com.rallyhealth.weepickle.v1.core.Util.parseLong(d, 0, d.length())

--- a/weepickle/test/src/com/rallyhealth/weepickle/v1/StructTests.scala
+++ b/weepickle/test/src/com/rallyhealth/weepickle/v1/StructTests.scala
@@ -246,10 +246,11 @@ object StructTests extends TestSuite {
     }
 
     test("extra") {
-      val uuidString = "01020304-0506-0708-0901-020304050607"
-      val uuid = UUID.fromString(uuidString)
       test("UUID") {
-        rw(uuid, s""" "$uuidString" """)
+        (1 to 100).foreach { _ =>
+          val uuid = UUID.randomUUID()
+          rw(uuid, s""" "${uuid.toString}" """)
+        }
       }
     }
 


### PR DESCRIPTION
This PR make parsing of valid 36-byte UUIDs faster in 2x-7x times (depending on JDK version) without changes in handling of errors and shorter (like `"0-0-0-0-0"`) or longer (yeap, the standard Java parser accepts them) values.

Bellow are results of benchmarks that parses an array of 128 JSON strings to an array of UUIDs.

## JDK 8
### Before
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                             (size)   Mode  Cnt       Score      Error  Units
[info] ArrayOfUUIDsReading.avSystemGenCodec     128  thrpt    5   14120.908 ±  124.210  ops/s
[info] ArrayOfUUIDsReading.borerJson            128  thrpt    5   13506.458 ±  126.836  ops/s
[info] ArrayOfUUIDsReading.circe                128  thrpt    5   12791.404 ±  112.205  ops/s
[info] ArrayOfUUIDsReading.dslJsonScala         128  thrpt    5  127389.261 ± 8247.226  ops/s
[info] ArrayOfUUIDsReading.jacksonScala         128  thrpt    5   60863.041 ±  433.560  ops/s
[info] ArrayOfUUIDsReading.jsoniterScala        128  thrpt    5  232451.966 ±  503.282  ops/s
[info] ArrayOfUUIDsReading.playJson             128  thrpt    5   12231.396 ±  116.315  ops/s
[info] ArrayOfUUIDsReading.sprayJson            128  thrpt    5    8596.765 ±   39.366  ops/s
[info] ArrayOfUUIDsReading.uPickle              128  thrpt    5   12873.315 ±  112.585  ops/s
[info] ArrayOfUUIDsReading.weePickle            128  thrpt    5   78200.411 ±  403.595  ops/s
```
### After
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                             (size)   Mode  Cnt       Score      Error  Units
[info] ArrayOfUUIDsReading.avSystemGenCodec     128  thrpt    5   14134.050 ±  271.126  ops/s
[info] ArrayOfUUIDsReading.borerJson            128  thrpt    5   14066.702 ±  241.422  ops/s
[info] ArrayOfUUIDsReading.circe                128  thrpt    5   12880.728 ±   98.472  ops/s
[info] ArrayOfUUIDsReading.dslJsonScala         128  thrpt    5  129764.835 ± 5411.463  ops/s
[info] ArrayOfUUIDsReading.jacksonScala         128  thrpt    5   60901.845 ±  693.853  ops/s
[info] ArrayOfUUIDsReading.jsoniterScala        128  thrpt    5  232747.513 ± 1583.347  ops/s
[info] ArrayOfUUIDsReading.playJson             128  thrpt    5   12136.594 ±  109.441  ops/s
[info] ArrayOfUUIDsReading.sprayJson            128  thrpt    5    8472.291 ±   30.612  ops/s
[info] ArrayOfUUIDsReading.uPickle              128  thrpt    5   12786.165 ±   83.007  ops/s
[info] ArrayOfUUIDsReading.weePickle            128  thrpt    5   13626.593 ±   59.815  ops/s
```

## JDK 15 (early access build)
### Before
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                             (size)   Mode  Cnt       Score     Error  Units
[info] ArrayOfUUIDsReading.avSystemGenCodec     128  thrpt    5   46183.155 ± 937.379  ops/s
[info] ArrayOfUUIDsReading.borerJson            128  thrpt    5   44264.778 ± 212.971  ops/s
[info] ArrayOfUUIDsReading.circe                128  thrpt    5   42792.567 ± 405.623  ops/s
[info] ArrayOfUUIDsReading.dslJsonScala         128  thrpt    5  133557.129 ± 768.991  ops/s
[info] ArrayOfUUIDsReading.jacksonScala         128  thrpt    5   69787.906 ± 411.977  ops/s
[info] ArrayOfUUIDsReading.jsoniterScala        128  thrpt    5  245148.416 ± 859.087  ops/s
[info] ArrayOfUUIDsReading.playJson             128  thrpt    5   34075.409 ± 576.833  ops/s
[info] ArrayOfUUIDsReading.sprayJson            128  thrpt    5   16602.146 ± 102.506  ops/s
[info] ArrayOfUUIDsReading.uPickle              128  thrpt    5   42198.354 ± 113.721  ops/s
[info] ArrayOfUUIDsReading.weePickle            128  thrpt    5   46137.451 ± 198.240  ops/s
```

## After
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                             (size)   Mode  Cnt       Score      Error  Units
[info] ArrayOfUUIDsReading.avSystemGenCodec     128  thrpt    5   46495.502 ± 6443.539  ops/s
[info] ArrayOfUUIDsReading.borerJson            128  thrpt    5   43898.673 ±  218.682  ops/s
[info] ArrayOfUUIDsReading.circe                128  thrpt    5   43556.177 ± 2813.515  ops/s
[info] ArrayOfUUIDsReading.dslJsonScala         128  thrpt    5  134310.037 ±   80.774  ops/s
[info] ArrayOfUUIDsReading.jacksonScala         128  thrpt    5   67943.927 ± 2773.123  ops/s
[info] ArrayOfUUIDsReading.jsoniterScala        128  thrpt    5  245192.736 ± 1183.365  ops/s
[info] ArrayOfUUIDsReading.playJson             128  thrpt    5   33917.537 ±  699.567  ops/s
[info] ArrayOfUUIDsReading.sprayJson            128  thrpt    5   16902.428 ±  148.481  ops/s
[info] ArrayOfUUIDsReading.uPickle              128  thrpt    5   38186.043 ±  198.256  ops/s
[info] ArrayOfUUIDsReading.weePickle            128  thrpt    5   84668.581 ±  341.207  ops/s
```