### PR TITLE
Add ZonedDateTime to implicits and readme

### DIFF
--- a/implicits/src-jvm/com/rallyhealth/weepickle/v1/implicits/Froms.scala
+++ b/implicits/src-jvm/com/rallyhealth/weepickle/v1/implicits/Froms.scala
@@ -11,6 +11,7 @@ trait Froms extends DefaultFroms {
   implicit val FromLocalTime: From[LocalTime] = FromString.comap[LocalTime](_.toString)
   implicit val FromLocalDateTime: From[LocalDateTime] = FromString.comap[LocalDateTime](_.toString)
   implicit val FromOffsetDateTime: From[OffsetDateTime] = FromString.comap[OffsetDateTime](_.toString)
+  implicit val FromZonedDateTime: From[ZonedDateTime] = FromString.comap[ZonedDateTime](_.toString)
   implicit val FromInstant: From[Instant] = new From[Instant] {
     override def transform0[V](v: Instant, out: Visitor[_, V]): V = out.visitTimestamp(v)
   }

--- a/implicits/src-jvm/com/rallyhealth/weepickle/v1/implicits/Tos.scala
+++ b/implicits/src-jvm/com/rallyhealth/weepickle/v1/implicits/Tos.scala
@@ -17,6 +17,9 @@ trait Tos extends DefaultTos {
   implicit val ToOffsetDateTime: To[OffsetDateTime] = new MapStringTo(
     s => OffsetDateTime.parse(s.toString)
   )
+  implicit val ToZonedDateTime: To[ZonedDateTime] = new MapStringTo(
+    s => ZonedDateTime.parse(s.toString)
+  )
   implicit val ToInstant: To[Instant] = new SimpleTo[Instant] {
     override def expectedMsg: String = "expected timestamp"
     override def visitTimestamp(instant: Instant): Instant = instant

--- a/readme.md
+++ b/readme.md
@@ -73,7 +73,7 @@ The following is a non-exhaustive map of type support:
 - `Tuple`s from 1 to 22
 - Immutable `Seq`, `List`, `Vector`, `Set`, `SortedSet`, `Option`, `Array`, `Maps`, and all other collections with a reasonable `CanBuildFrom` implementation
 - `Duration`, `Either`,
-- `Date`, `Instant`, `LocalDate`, `LocalTime`, `LocalDateTime`, `OffsetDateTime`
+- `Date`, `Instant`, `LocalDate`, `LocalTime`, `LocalDateTime`, `OffsetDateTime`, `ZonedDateTime`
 - Stand-alone `case class`es and `case object`s, and their generic equivalents,
 - Non-generic `case class`es and `case object`s that are part of a `sealed trait` or `sealed class` hierarchy
 - `sealed trait` and `sealed class`es themselves, assuming that all subclasses are picklable

--- a/weepickle/test/src-jvm/com/rallyhealth/weepickle/v1/example/JvmPrimitiveTests.scala
+++ b/weepickle/test/src-jvm/com/rallyhealth/weepickle/v1/example/JvmPrimitiveTests.scala
@@ -16,7 +16,7 @@ object JvmPrimitiveTests extends TestSuite {
       test("LocalTime") { rw(LocalTime.parse("00:00"), "\"00:00\"") }
       test("LocalDateTime") { rw(LocalDateTime.parse("2000-01-01T00:00:00"), "\"2000-01-01T00:00:00\"") }
       test("OffsetDateTime") { rw(OffsetDateTime.parse("2007-12-03T10:15:30+01:00"), "\"2007-12-03T10:15:30+01:00\"") }
-      test("ZonedDateTime") {rw(ZonedDateTime.parse("2000-01-01T00:00:00Z"), "\"2000-01-01T00:00:00Z\"") }
+      test("ZonedDateTime") {rw(ZonedDateTime.parse("2000-01-01T00:00:00.000-06:00[America/Chicago]"), "\"2000-01-01T00:00:00.000-06:00[America/Chicago]\"") }
       test("Instant") {
         test("String") { rw(Instant.parse("2015-05-03T10:15:30Z"), "\"2015-05-03T10:15:30Z\"") }
         test("Millis") {

--- a/weepickle/test/src-jvm/com/rallyhealth/weepickle/v1/example/JvmPrimitiveTests.scala
+++ b/weepickle/test/src-jvm/com/rallyhealth/weepickle/v1/example/JvmPrimitiveTests.scala
@@ -16,6 +16,7 @@ object JvmPrimitiveTests extends TestSuite {
       test("LocalTime") { rw(LocalTime.parse("00:00"), "\"00:00\"") }
       test("LocalDateTime") { rw(LocalDateTime.parse("2000-01-01T00:00:00"), "\"2000-01-01T00:00:00\"") }
       test("OffsetDateTime") { rw(OffsetDateTime.parse("2007-12-03T10:15:30+01:00"), "\"2007-12-03T10:15:30+01:00\"") }
+      test("ZonedDateTime") {rw(ZonedDateTime.parse("2000-01-01T00:00:00Z"), "\"2000-01-01T00:00:00Z\"") }
       test("Instant") {
         test("String") { rw(Instant.parse("2015-05-03T10:15:30Z"), "\"2015-05-03T10:15:30Z\"") }
         test("Millis") {


### PR DESCRIPTION
We support Date, Instant, LocalDate, LocalTime, LocalDateTime, and OffsetDateTime already. This adds ZonedDateTime to the list of types supported implicitly from/to.