### PR TITLE
[WIP] - error - macros has not been expanded

### DIFF
--- a/weepickle/test/src/com/rallyhealth/weepickle/v1/example/ExampleTests.scala
+++ b/weepickle/test/src/com/rallyhealth/weepickle/v1/example/ExampleTests.scala
@@ -65,6 +65,20 @@ case class Maybe2(@dropDefault i: Option[Int] = None)
 object Maybe2 {
   implicit val rw = WeePickle.macroFromTo[Maybe2]
 }
+case class Maybe3(i: Option[Int] = None)
+object Maybe3 {
+  implicit val rw = WeePickle.macroFromTo[Maybe3]
+}
+case class Maybe4(i: Int, @dropDefault j: Option[Int] = None)
+object Maybe4 {
+  implicit lazy val rw = WeePickle.macroFromTo[Maybe4]
+  def apply(maybe3: Maybe3): Maybe4 = Maybe4(maybe3.i.get)
+}
+case class Maybe5(i: Int, j: Option[Int] = None)
+object Maybe5 {
+  implicit lazy val rw = WeePickle.macroFromTo[Maybe5]
+  def apply(maybe3: Maybe3): Maybe5 = Maybe5(maybe3.i.get)
+}
 object Keyed {
   case class KeyBar(@com.rallyhealth.weepickle.v1.implicits.key("hehehe") kekeke: Int)
   object KeyBar {
@@ -210,6 +224,14 @@ object ExampleTests extends TestSuite {
         FromJson("""{"i":42}""").transform(ToScala[Maybe1]) ==> Maybe1(Some(42))
 
         FromScala(Maybe2(None)).transform(ToJson.string) ==> """{}"""
+
+        FromScala(Maybe2()).transform(ToJson.string) ==> """{}"""
+
+        FromScala(Maybe3()).transform(ToJson.string) ==> """{"i":null}"""
+
+        FromScala(Maybe4(Maybe3(Some(1)))).transform(ToJson.string) ==> """{"i":1}"""
+
+        FromScala(Maybe5(Maybe3(Some(1)))).transform(ToJson.string) ==> """{"i":1}"""
       }
       test("tuples") {
         FromScala((1, "omg")).transform(ToJson.string) ==> """[1,"omg"]"""


### PR DESCRIPTION
Encountering macros expansion error at **compile time** in the below two examples `Maybe4` and `Maybe5`.

`[error] /Users/pawan.araballi/code/weePickle/weepickle/test/src/com/rallyhealth/weepickle/v1/example/ExampleTests.scala:74:47: macro has not been expanded
[error]   implicit lazy val rw = WeePickle.macroFromTo[Maybe4]
[error]                                               ^
[error] /Users/pawan.araballi/code/weePickle/weepickle/test/src/com/rallyhealth/weepickle/v1/example/ExampleTests.scala:79:47: macro has not been expanded
[error]   implicit lazy val rw = WeePickle.macroFromTo[Maybe5]
[error]                                               ^
[error] two errors found`.

It throws a default error when `weepickle` is used in application `value apply$default$11 is not a member of object RPSessionCacheModel`

I am investigating in `Macros.scala` https://github.com/rallyhealth/weePickle/blob/7c15771644c654593067afc329f9c3a8898b82cd/implicits/src/com/rallyhealth/weepickle/v1/implicits/internal/Macros.scala to understand the behavior.