### PR TITLE
Encode Map[NonString, T] as {}, not []

### DIFF
--- a/implicits/src/com/rallyhealth/weepickle/v1/implicits/DefaultFroms.scala
+++ b/implicits/src/com/rallyhealth/weepickle/v1/implicits/DefaultFroms.scala
@@ -85,20 +85,18 @@ trait DefaultFroms
     implicit kw: From[K],
     vw: From[V]
   ): From[M[K, V]] = {
-    if (kw eq FromString) new From[M[String, V]] {
-      def transform0[R](v: M[String, V], out: Visitor[_, R]): R = {
+    new From[M[K, V]] {
+      def transform0[R](v: M[K, V], out: Visitor[_, R]): R = {
         val ctx = out.visitObject(v.size).narrow
         for (pair <- v) {
           val (k1, v1) = pair
           val keyVisitor = ctx.visitKey()
-          ctx.visitKeyValue(keyVisitor.visitString(k1))
+          ctx.visitKeyValue(kw.transform(k1, keyVisitor))
           ctx.visitValue(vw.transform(v1, ctx.subVisitor))
-
         }
         ctx.visitEnd()
       }
     }.asInstanceOf[From[M[K, V]]]
-    else SeqLikeFrom[Seq, (K, V)].comap[M[K, V]](_.toSeq)
   }
   implicit def MapFrom1[K, V](
     implicit kw: From[K],

--- a/weepickle/test/src/com/rallyhealth/weepickle/v1/ClassDefs.scala
+++ b/weepickle/test/src/com/rallyhealth/weepickle/v1/ClassDefs.scala
@@ -483,3 +483,8 @@ object Ast {
 }
 
 case class CaseClassWithJson(json: com.rallyhealth.weejson.v1.Value)
+
+class StringAnyVal(val string: String) extends AnyVal
+object StringAnyVal {
+  implicit val pickler = WeePickle.fromTo[String].bimap[StringAnyVal](_.string, new StringAnyVal(_))
+}

--- a/weepickle/test/src/com/rallyhealth/weepickle/v1/StructTests.scala
+++ b/weepickle/test/src/com/rallyhealth/weepickle/v1/StructTests.scala
@@ -14,6 +14,7 @@ import com.rallyhealth.weepack.v1.ToMsgPack
 import com.rallyhealth.weepickle.v1.TestUtil._
 import com.rallyhealth.weepickle.v1.WeePickle.{FromScala, ToScala}
 import com.rallyhealth.weepickle.v1.core.Abort
+import com.rallyhealth.weepickle.v1.example.Suit
 
 import scala.reflect.ClassTag
 import language.postfixOps
@@ -108,6 +109,16 @@ object StructTests extends TestSuite {
         test("non-string key") - {
           TestUtil.rw(Map(new StringAnyVal("a") -> 1),
             """{"a":1}"""
+          )
+        }
+        test("enum key") - {
+          TestUtil.rw(Map(Suit.Spades -> "king"),
+            """{"Spades":"king"}"""
+          )
+        }
+        test("enum value") - {
+          TestUtil.rw(Map("king" -> Suit.Spades),
+            """{"king":"Spades"}"""
           )
         }
       }

--- a/weepickle/test/src/com/rallyhealth/weepickle/v1/StructTests.scala
+++ b/weepickle/test/src/com/rallyhealth/weepickle/v1/StructTests.scala
@@ -19,7 +19,7 @@ import scala.reflect.ClassTag
 import language.postfixOps
 
 object StructTests extends TestSuite {
-  Seq(1).to(Vector)
+
   val tests = Tests {
     test("arrays") {
       test("empty") - rwk(Array[Int](), "[]")(_.toSeq)
@@ -69,25 +69,21 @@ object StructTests extends TestSuite {
         test("SortedSet") - rw(collection.mutable.SortedSet("omg", "i am", "cow"), """["cow","i am","omg"]""")
       }
       test("Map") {
-        test("Structured") - rw(
-          Map(Nil -> List(1), List(1) -> List(1, 2, 3)),
-          "[[[],[1]],[[1],[1,2,3]]]"
+        test("Structured") - roundTripMsgPack(
+          Map(Nil -> List(1), List(1) -> List(1, 2, 3))
         )
-        test("Structured2") - rw(
-          collection.mutable.Map(Nil -> List(1), List(1) -> List(1, 2, 3)),
-          "[[[],[1]],[[1],[1,2,3]]]"
+        test("Structured2") - roundTripMsgPack(
+          collection.mutable.Map(Nil -> List(1), List(1) -> List(1, 2, 3))
         )
-        test("Structured3") - rw(
-          collection.immutable.Map(Nil -> List(1), List(1) -> List(1, 2, 3)),
-          "[[[],[1]],[[1],[1,2,3]]]"
+        test("Structured3") - roundTripMsgPack(
+          collection.immutable.Map(Nil -> List(1), List(1) -> List(1, 2, 3))
         )
-        test("Structured4") - rw(
-          collection.Map(Nil -> List(1), List(1) -> List(1, 2, 3)),
-          "[[[],[1]],[[1],[1,2,3]]]"
+        test("Structured4") - roundTripMsgPack(
+          collection.Map(Nil -> List(1), List(1) -> List(1, 2, 3))
         )
         test("StructuredEmpty") - rw(
           Map[List[Int], List[Int]](),
-          "[]"
+          "{}"
         )
         test("String") - rw(
           Map("Hello" -> List(1), "World" -> List(1, 2, 3)),
@@ -109,6 +105,11 @@ object StructTests extends TestSuite {
           Map[String, List[Int]](),
           "{}"
         )
+        test("non-string key") - {
+          TestUtil.rw(Map(new StringAnyVal("a") -> 1),
+            """{"a":1}"""
+          )
+        }
       }
     }
 
@@ -201,8 +202,8 @@ object StructTests extends TestSuite {
 
     test("combinations") {
       test("SeqListMapOptionString") - rw[Seq[List[Map[Option[String], String]]]](
-        Seq(Nil, List(Map(Some("omg") -> "omg"), Map(Some("lol") -> "lol", None -> "")), List(Map())),
-        """[[],[[["omg","omg"]],[["lol","lol"],[null,""]]],[[]]]"""
+        Seq(Nil, List(Map(Some("omg") -> "omg"), Map(Some("lol") -> "lol")), List(Map())),
+        """[[],[{"omg":"omg"},{"lol":"lol"}],[{}]]"""
       )
 
       // This use case is not currently supported in the rallyhealth/weepickle fork.
@@ -228,23 +229,6 @@ object StructTests extends TestSuite {
       }
     }
 
-    test("writeBytesTo") {
-      test("json") {
-        type Thing = Seq[List[Map[Option[String], String]]]
-        val thing: Thing = Seq(Nil, List(Map(Some("omg") -> "omg"), Map(Some("lol") -> "lol", None -> "")), List(Map()))
-        val out = new ByteArrayOutputStream()
-        FromScala(thing).transform(ToJson.outputStream(out))
-        out.toByteArray ==> FromScala(thing).transform(ToJson.string).getBytes
-      }
-      test("msgpack") {
-        type Thing = Seq[List[Map[Option[String], String]]]
-        val thing: Thing = Seq(Nil, List(Map(Some("omg") -> "omg"), Map(Some("lol") -> "lol", None -> "")), List(Map()))
-        val out = new ByteArrayOutputStream()
-        FromScala(thing).transform(ToMsgPack.outputStream(out))
-        out.toByteArray ==> FromScala(thing).transform(ToMsgPack.bytes)
-      }
-    }
-
     test("transmutation") {
       test("vectorToList") {
         val vectorToList =
@@ -254,14 +238,6 @@ object StructTests extends TestSuite {
           vectorToList == List(1.1, 2.2, 3.3)
         )
 
-      }
-      test("listToMap") {
-        val listToMap =
-          FromJson(FromScala(List((1, "1"), (2, "2"))).transform(ToJson.string)).transform(ToScala[Map[Int, String]])
-        assert(
-          listToMap.isInstanceOf[Map[Int, String]],
-          listToMap == Map(1 -> "1", 2 -> "2")
-        )
       }
     }
 

--- a/weepickle/test/src/com/rallyhealth/weepickle/v1/TestUtil.scala
+++ b/weepickle/test/src/com/rallyhealth/weepickle/v1/TestUtil.scala
@@ -3,6 +3,7 @@ import utest._
 import acyclic.file
 import com.rallyhealth.weejson.v1.jackson.{FromJson, ToJson}
 import com.rallyhealth.weepack.v1.{FromMsgPack, ToMsgPack}
+import com.rallyhealth.weepickle.v1.WeePickle.{FromScala, ToScala}
 
 /**
   * Created by haoyi on 4/22/14.
@@ -56,6 +57,12 @@ class TestUtil[Api <: com.rallyhealth.weepickle.v1.Api](val api: Api) {
       val rewrittenBinaryStr = com.rallyhealth.weepickle.v1.core.TestUtil.bytesToString(rewrittenBinary)
       assert(writtenBinaryStr == rewrittenBinaryStr)
     }
+  }
+
+  def roundTripMsgPack[T: WeePickle.From: WeePickle.To](in: T) = {
+    val msgPack = FromScala(in).transform(ToMsgPack.bytes)
+    val roundTripped = FromMsgPack(msgPack).transform(ToScala[T])
+    assert(in == roundTripped)
   }
 
   def assertNumberFormatException[T: api.To](s: String) = {


### PR DESCRIPTION
## Summary
Changes `From[Map[K, V]]` to always encode as `{"k": v, ...}` rather than `[[k, v], ...]` even if `K` != `String`.

## Details
Consider:
* `Map[Enum, T]`
* `Map[AnyValString, T]`

WeePickle currently encodes these `Map`s as `[[key1, value1], [key2, value2], ...]`. This behavior came from uPickle, but has surprised two users of weePickle.

`[[key1, value1], [key2, value2], ...]` is not an idiomatic way to represent maps in JSON. I assume this encoding was chosen because uPickle values generality. For example, mill caches every task output. If a task returns `Map[Int, String]`, mill needs to be able to roundtrip the value through disk as json.

The default implementation of `From[Map[K, V]]` checks if the `From[Key] eq FromString`, and if so, encodes with curlies, i.e. `{"key1": ...}`. JSON only allows String keys. WeePickle knows that `WeePickle.FromString` will only ever call `visitString()`, so this is likely safe for JSON.

The `From[]` instances above also only ever call `visitString()`, but weePickle has no way of knowing their behavior. Instead of generating invalid json or throwing, weePickle instead generates non-idiomatic json that is likely not what the user wants.

This PR changes the behavior of `From[Map[K, V]]` to always write curlies. This makes the behavior of weepickle simpler and less surprising, but also reduces the domain of possible inputs that can be encoded as valid JSON. For example, a `From[K]` that writes a key as something other than `visitString()` will cause jackson's `JsonGenerator` to throw. `Map[Option[String], V]` will compile, but throw on `Map(None -> 1)` when writing to JSON.

It's worth noting that the "strings must be keys" restriction applies to JSON, but not to MsgPack. After this change, MessagePack output will become _more_ idiomatic for non-string keys, FWIW.

Given that key restrictions are a JSON thing, is it worth adding handling to `ToJson` to massage non-String inputs to String valued keys? If so, how? One possible approach would be to encode non-String keys as JSON texts encoded into a json string. A shortcoming of this approach is that it is a one-way operation. Some types like `ToDouble` happen to implement `visitString`, but `ToBoolean`, `ToInt`, and case class macros do not.

For now, it's up to the caller to ensure that `Map` key types encode to and from `String`s if they want to encode to JSON.

@russellremple @jducoeur @BurgersMcSlopshot @zzpxyx