### PR TITLE
#30 Add dropAlways annotation

### DIFF
--- a/implicits/src/com/rallyhealth/weepickle/v1/implicits/dropAlways.scala
+++ b/implicits/src/com/rallyhealth/weepickle/v1/implicits/dropAlways.scala
@@ -4,8 +4,9 @@ import scala.annotation.StaticAnnotation
 
 /**
  * Used to ignore a certain case class field at serialization.
+ * Supersedes [[dropDefault]] if used together (though it wouldn't make sense to have both, anyway).
  *
  * Inspired by Jackson:
  * https://fasterxml.github.io/jackson-annotations/javadoc/2.5/com/fasterxml/jackson/annotation/JsonIgnore.html
  */
-class jsonIgnore extends StaticAnnotation
+class dropAlways extends StaticAnnotation

--- a/implicits/src/com/rallyhealth/weepickle/v1/implicits/internal/Macros.scala
+++ b/implicits/src/com/rallyhealth/weepickle/v1/implicits/internal/Macros.scala
@@ -69,16 +69,17 @@ object Macros {
       default: c.Tree,
       localTo: TermName,
       aggregate: TermName,
-      omitJson: Boolean
+      omitAlways: Boolean
     ) {
-      def writingCheckDefault: Boolean = (hasDefault && omitDefault) || omitJson
+      def writingCheckDefault: Boolean = hasDefault && omitDefault
       def readingCheckDefault: Boolean = hasDefault || assumeDefaultNone
     }
 
     private[internal] object Argument {
 
-      private def shouldIgnoreJson(argSym: c.Symbol): Boolean =
+      private def shouldDropAlways(argSym: c.Symbol): Boolean =
         argSym.annotations.exists(_.tree.tpe == typeOf[dropAlways])
+      
       /**
         * Unlike lihaoyi/upickle, rallyhealth/weepickle will write values even if they're
         * the same as the default value, unless instructed explicitly not to with the
@@ -146,7 +147,7 @@ object Macros {
           default = deriveDefault(companion, index, isParamWithDefault, isOptionWithoutDefault),
           localTo = TermName("localTo" + index),
           aggregate = TermName("aggregated" + index),
-          omitJson = shouldIgnoreJson(argSym)
+          omitAlways = shouldDropAlways(argSym)
         )
       }
     }
@@ -395,9 +396,9 @@ object Macros {
         """
 
         /**
-          * @see [
+          * @see [[shouldDropAlways()]]
           */
-        if (arg.omitJson)
+        if (arg.omitAlways)
           q""""""
         /**
          * @see [[shouldDropDefault()]]

--- a/implicits/src/com/rallyhealth/weepickle/v1/implicits/jsonIgnore.scala
+++ b/implicits/src/com/rallyhealth/weepickle/v1/implicits/jsonIgnore.scala
@@ -1,0 +1,11 @@
+package com.rallyhealth.weepickle.v1.implicits
+
+import scala.annotation.StaticAnnotation
+
+/**
+ * Used to ignore a certain case class field at serialization.
+ *
+ * Inspired by Jackson:
+ * https://fasterxml.github.io/jackson-annotations/javadoc/2.5/com/fasterxml/jackson/annotation/JsonIgnore.html
+ */
+class jsonIgnore extends StaticAnnotation

--- a/weepickle/test/src/com/rallyhealth/weepickle/v1/ClassDefs.scala
+++ b/weepickle/test/src/com/rallyhealth/weepickle/v1/ClassDefs.scala
@@ -1,8 +1,8 @@
 package com.rallyhealth.weepickle.v1
 
 //import com.rallyhealth.weepickle.v1.ADTs.ADT0
-import WeePickle.{FromTo => RW, To => R, From => W}
-import com.rallyhealth.weepickle.v1.implicits.key
+import WeePickle.{From => W, FromTo => RW, To => R}
+import com.rallyhealth.weepickle.v1.implicits.{jsonIgnore, key}
 /*
  * A whole bunch of test data that can be used by client libraries to try out
  * their typeclass derivation to make sure it's doing the right thing. Contains
@@ -191,6 +191,10 @@ object Annotated {
   @key("1") case class C(@key("lol") s1: String, @key("wtf") s2: String) extends A
   object C {
     implicit def rw: RW[C] = WeePickle.macroFromTo
+  }
+  case class D(a: String, @jsonIgnore b: Option[String], c: String)
+  object D {
+    implicit def rw: RW[D] = WeePickle.macroFromTo
   }
 }
 object Defaults {

--- a/weepickle/test/src/com/rallyhealth/weepickle/v1/MacroTests.scala
+++ b/weepickle/test/src/com/rallyhealth/weepickle/v1/MacroTests.scala
@@ -234,16 +234,8 @@ object MacroTests extends TestSuite {
       }
       test("ignoreAnnotatedFieldsWhenSerializing") {
         import Annotated.D
-        val w = FromScala(D("a",Some("b"),"c")).transform(ToJson.string)
-        assert(w == """{"a": "a", "c": "c"}"""" )
-
-        /**
-         * Fails :(
-         * assert(w == """{"a": "a", "c": "c"}"""" )
-         * w: String = {"a":"a","b":"b","c":"c"}
-         * utest.AssertionError: assert(w == """{"a": "a", "c": "c"}"""" )
-         * w: String = {"a":"a","b":"b","c":"c"}
-         */
+        val w = FromScala(D("a", Some("b"), "c")).transform(ToJson.string)
+        assert(w == """{"a":"a","c":"c"}""")
       }
     }
 

--- a/weepickle/test/src/com/rallyhealth/weepickle/v1/MacroTests.scala
+++ b/weepickle/test/src/com/rallyhealth/weepickle/v1/MacroTests.scala
@@ -1,9 +1,9 @@
 package com.rallyhealth.weepickle.v1
 import acyclic.file
-import com.rallyhealth.weejson.v1.jackson.FromJson
+import com.rallyhealth.weejson.v1.jackson.{FromJson, ToJson}
 import utest._
 import com.rallyhealth.weepickle.v1.TestUtil._
-import com.rallyhealth.weepickle.v1.WeePickle.ToScala
+import com.rallyhealth.weepickle.v1.WeePickle.{FromScala, ToScala}
 import com.rallyhealth.weepickle.v1.core.MutableCharSequenceVisitor
 
 object Custom {
@@ -231,6 +231,19 @@ object MacroTests extends TestSuite {
         val r2 =
           FromJson("""{"i":123, "j":false, "k":"haha", "s":"kk", "l":true, "z":[1, 2, 3]}""").transform(ToScala[ADTb])
         assert(r2 == ADTb(123, "kk"))
+      }
+      test("ignoreAnnotatedFieldsWhenSerializing") {
+        import Annotated.D
+        val w = FromScala(D("a",Some("b"),"c")).transform(ToJson.string)
+        assert(w == """{"a": "a", "c": "c"}"""" )
+
+        /**
+         * Fails :(
+         * assert(w == """{"a": "a", "c": "c"}"""" )
+         * w: String = {"a":"a","b":"b","c":"c"}
+         * utest.AssertionError: assert(w == """{"a": "a", "c": "c"}"""" )
+         * w: String = {"a":"a","b":"b","c":"c"}
+         */
       }
     }
 


### PR DESCRIPTION
Lets you annotate a case class field to flag it as something to ignore during serialization.

Resolves #30 


```scala
 ✘  AWS: care-rally-dev  jasna.blemberg@jasna-blemberg  ~/code/weePickle   issue30  mill __.test
[256/2037] implicits.jvm[2.11.12].compile 
[info] Compiling 1 Scala source to /Users/jasna.blemberg/code/weePickle/out/implicits/jvm/2.11.12/compile/dest/classes ...
[info] Done compiling.
[271/2037] implicits.jvm[2.11.12].reportBinaryIssues 
1 targets failed
implicits.jvm[2.11.12].reportBinaryIssues java.lang.RuntimeException: Compared to artifact: /Users/jasna.blemberg/Library/Caches/Coursier/v1/https/dl.bintray.com/rallyhealth/maven/com/rallyhealth/weepickle-implicits-v1_2.11/1.0.1/weepickle-implicits-v1_2.11-1.0.1.jar
found 3 binary incompatibilities:
method copy(Int,java.lang.String,java.lang.String,scala.reflect.api.Types#TypeApi,Boolean,Boolean,Boolean,scala.reflect.api.Trees#TreeApi,scala.reflect.api.Names#TermNameApi,scala.reflect.api.Names#TermNameApi)com.rallyhealth.weepickle.v1.implicits.internal.Macros#DeriveDefaults#Argument in class com.rallyhealth.weepickle.v1.implicits.internal.Macros#DeriveDefaults#Argument does not have a correspondent in current version
method this(com.rallyhealth.weepickle.v1.implicits.internal.Macros#DeriveDefaults,Int,java.lang.String,java.lang.String,scala.reflect.api.Types#TypeApi,Boolean,Boolean,Boolean,scala.reflect.api.Trees#TreeApi,scala.reflect.api.Names#TermNameApi,scala.reflect.api.Names#TermNameApi)Unit in class com.rallyhealth.weepickle.v1.implicits.internal.Macros#DeriveDefaults#Argument does not have a correspondent in current version
method apply(Int,java.lang.String,java.lang.String,scala.reflect.api.Types#TypeApi,Boolean,Boolean,Boolean,scala.reflect.api.Trees#TreeApi,scala.reflect.api.Names#TermNameApi,scala.reflect.api.Names#TermNameApi)com.rallyhealth.weepickle.v1.implicits.internal.Macros#DeriveDefaults#Argument in object com.rallyhealth.weepickle.v1.implicits.internal.Macros#DeriveDefaults#Argument does not have a correspondent in current version
    scala.sys.package$.error(package.scala:30)
    ammonite.$file.build$MiMa.$anonfun$reportBinaryIssues$2(build.sc:377)
    mill.define.Task$MappedDest.evaluate(Task.scala:337)
```