### PR TITLE
Make val not be lazy to prevent blocking

### DIFF
--- a/implicits/src/com/rallyhealth/weepickle/v1/implicits/MacroImplicits.scala
+++ b/implicits/src/com/rallyhealth/weepickle/v1/implicits/MacroImplicits.scala
@@ -341,7 +341,7 @@ object MacroImplicits {
       }
       q"""
         ..${for (arg <- args)
-        yield q"private[this] lazy val ${arg.localTo} = implicitly[${c.prefix}.To[${arg.argType}]]"}
+        yield q"private[this] val ${arg.localTo} = implicitly[${c.prefix}.To[${arg.argType}]]"}
         new ${c.prefix}.CaseR[$targetType]{
           @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.Null"))
           override def visitObject(length: Int) = new CaseObjectContext{

--- a/implicits/src/com/rallyhealth/weepickle/v1/implicits/internal/Macros.scala
+++ b/implicits/src/com/rallyhealth/weepickle/v1/implicits/internal/Macros.scala
@@ -296,7 +296,7 @@ object Macros {
       }
       q"""
         ..${for (arg <- args)
-        yield q"private[this] lazy val ${arg.localTo} = implicitly[${c.prefix}.To[${arg.argType}]]"}
+        yield q"private[this] val ${arg.localTo} = implicitly[${c.prefix}.To[${arg.argType}]]"}
         new ${c.prefix}.CaseR[$targetType]{
           override def visitObject(length: Int) = new CaseObjectContext{
             ..${for (arg <- args)

--- a/implicits/src/com/rallyhealth/weepickle/v1/implicits/internal/Macros.scala
+++ b/implicits/src/com/rallyhealth/weepickle/v1/implicits/internal/Macros.scala
@@ -296,7 +296,7 @@ object Macros {
       }
       q"""
         ..${for (arg <- args)
-        yield q"private[this] val ${arg.localTo} = implicitly[${c.prefix}.To[${arg.argType}]]"}
+        yield q"private[this] lazy val ${arg.localTo} = implicitly[${c.prefix}.To[${arg.argType}]]"}
         new ${c.prefix}.CaseR[$targetType]{
           override def visitObject(length: Int) = new CaseObjectContext{
             ..${for (arg <- args)


### PR DESCRIPTION
Context: https://rallyhealth.slack.com/archives/CSE35MYE8/p1593610303171600

> Mark: I’m getting a Blocked thread detected in non-blocking pool error during weepickle serialization as shown in splunk. Here’s a branch that triggers it. Is this likely a play issue?
> Doug: Looks like this is during app startup? Why are so many threads all trying to hit this Fact class at the same time?
> Mark: It’s coming from an automation test