### PR TITLE
Optimize: case class(@dropDefault v: Seq[T] = Nil)

### DIFF
--- a/implicits/src/com/rallyhealth/weepickle/v1/implicits/DefaultFroms.scala
+++ b/implicits/src/com/rallyhealth/weepickle/v1/implicits/DefaultFroms.scala
@@ -165,13 +165,10 @@ trait LowPriFroms extends com.rallyhealth.weepickle.v1.core.Types {
     new From[C[T]] {
       def transform0[R](v: C[T], out: Visitor[_, R]): R = {
         val ctx = out.visitArray(v.size).narrow
-        val x = v.iterator
-        while (x.nonEmpty) {
-          val next = x.next().asInstanceOf[T]
-          val written = r.transform(next, ctx.subVisitor)
+        v.asInstanceOf[Iterable[T]].foreach { t =>
+          val written = r.transform(t.asInstanceOf[T], ctx.subVisitor)
           ctx.visitValue(written)
         }
-
         ctx.visitEnd()
       }
     }

--- a/implicits/src/com/rallyhealth/weepickle/v1/implicits/internal/Macros.scala
+++ b/implicits/src/com/rallyhealth/weepickle/v1/implicits/internal/Macros.scala
@@ -394,7 +394,7 @@ object Macros {
         /**
           * @see [[shouldDropDefault()]]
           */
-        if (arg.writingCheckDefault) q"""if (v.${TermName(arg.raw)} != ${arg.default}) $snippet"""
+        if (arg.writingCheckDefault) q"""if (${arg.default} != v.${TermName(arg.raw)}) $snippet"""
         else snippet
       }
       q"""
@@ -404,7 +404,7 @@ object Macros {
             ..${for (arg <- args)
         yield {
           if (!arg.writingCheckDefault) q"n += 1"
-          else q"""if (v.${TermName(arg.raw)} != ${arg.default}) n += 1"""
+          else q"""if (${arg.default} != v.${TermName(arg.raw)}) n += 1"""
         }}
             n
           }


### PR DESCRIPTION
## Summary
Optimizes `case class(@dropDefault v: Seq[T] = Nil)` by replacing slow `Vector.equals()` with fast `Nil.equals()`.


## Background
My workload writes lots of `case class(@dropDefault v: Seq[T] = Nil)`. `CaseW.writeToObject` needs to check if each field value `==` the `@dropDefault` value to determine if it should write the field or not.

Most of my inputs are `Vector`, and my defaults are `Nil`.

<img width="1722" alt="Screen Shot 2020-08-08 at 7 42 36 PM" src="https://user-images.githubusercontent.com/663139/89721766-94f7e680-d9af-11ea-99ed-ff0435d7282e.png">

## `vector == Nil` vs `Nil == vector`
`Nil.equals()` is much better optimized than everything else. Specifically, it calls `that.isEmpty` rather than `this sameElements that`, which avoids an iterator allocation.

```
case object Nil extends List[Nothing] {
  // Removal of equals method here might lead to an infinite recursion similar to IntMap.equals.
  override def equals(that: Any) = that match {
    case that1: scala.collection.GenSeq[_] => that1.isEmpty
    case _ => false
  }
}
```

`Nil` is a common default for our case classes. Swapping the order of the comparison should better exploit the optimized `Nil.equals` implementation. I'm not sure how significantly it'll help in practice, but it'll at least eliminate the `VectorIterator`s from my profiler results.

```
Benchmark                    Mode  Cnt    Score    Error  Units
SanityBench.nilEqualsVector  avgt    3   59.407 ±  4.694  ns/op
SanityBench.vectorEqualsNil  avgt    3  254.292 ± 15.983  ns/op
```

@plokhotnyuk @russellremple @jebarb @jducoeur @vito-c