### PR TITLE
Suppress wartremover warnings

### DIFF
--- a/implicits/src/com/rallyhealth/weepickle/v1/implicits/MacroImplicits.scala
+++ b/implicits/src/com/rallyhealth/weepickle/v1/implicits/MacroImplicits.scala
@@ -343,6 +343,7 @@ object MacroImplicits {
         ..${for (arg <- args)
         yield q"private[this] lazy val ${arg.localTo} = implicitly[${c.prefix}.To[${arg.argType}]]"}
         new ${c.prefix}.CaseR[$targetType]{
+          @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.Null"))
           override def visitObject(length: Int) = new CaseObjectContext{
             ..${for (arg <- args)
         yield q"private[this] var ${arg.aggregate}: ${arg.argType} = _"}
@@ -359,6 +360,7 @@ object MacroImplicits {
               }
             }
 
+            @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.Null"))
             def visitEnd() = {
               ..${applyDefaultsWhenMissing(args)}
 
@@ -481,6 +483,7 @@ object MacroImplicits {
       }
       q"""
         new ${c.prefix}.CaseW[$targetType]{
+          @SuppressWarnings(Array("org.wartremover.warts.Var"))
           def length(v: $targetType) = {
             var n = 0
             ..${for (arg <- args)


### PR DESCRIPTION
I use wartremover in one library that uses WeePickle already, and in a few other projects that are ramping up on WeePickle soon. In the one library, I have to include warning suppressions whenever I reference a WeePickle macro, e.g. 
```scala
  @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.Null"))
  implicit val fileLineFormatter: FromTo[FileLine] = macroFromTo
```
I find this to be a kind of ugly boilerplate. Others have pointed out this issue in the past, e.g.,  [this](https://github.com/wartremover/wartremover/issues/215) from over 4 years ago, but nothing was ever done about it globally within wartremover. So I'm adding these suppressions directly in the macro expansions themselves as the next best (and most achievable) thing. Note that this does not introduce any dependencies on wartremover as `SuppressWarnings` is a `java.lang` annotation. Also note that I'm looking forward to moving from wartremover to ScalaFix once it can do all I need it to do. AFAIK, [this](https://github.com/scalameta/scalameta/issues/1212) is still blocking the inclusion of something like NonUnitStatements based on [this](https://github.com/scalacenter/scalafix/issues/529).

@htmldoug @jducoeur 