### PR TITLE
Support maps with non-string keys

### DIFF
--- a/core/src/com/rallyhealth/weepickle/v1/core/JsonPointerVisitor.scala
+++ b/core/src/com/rallyhealth/weepickle/v1/core/JsonPointerVisitor.scala
@@ -1,5 +1,7 @@
 package com.rallyhealth.weepickle.v1.core
 
+import java.util.Base64
+
 import com.rallyhealth.weepickle.v1.core.JsonPointerVisitor._
 
 import scala.annotation.tailrec
@@ -109,6 +111,73 @@ private class JsonPointerVisitor[T, J](
         override def visitString(cs: CharSequence): Any = {
           key = cs.toString
           wrap(this.delegate.visitString(key))
+        }
+
+        override def visitInt32(i: Int): Any = {
+          key = i.toString
+          wrap(this.delegate.visitInt32(i))
+        }
+
+        override def visitInt64(l: Long): Any = {
+          key = l.toString
+          wrap(this.delegate.visitInt64(l))
+        }
+
+        override def visitNull(): Any = {
+          key = "null"
+          wrap(this.delegate.visitNull())
+        }
+
+        override def visitTrue(): Any = {
+          key = "true"
+          wrap(this.delegate.visitTrue())
+        }
+
+        override def visitFalse(): Any = {
+          key = "false"
+          wrap(this.delegate.visitFalse())
+        }
+
+        override def visitFloat64StringParts(cs: CharSequence, decIndex: Int, expIndex: Int): Any = {
+          key = cs.toString
+          wrap(this.delegate.visitFloat64StringParts(cs, decIndex, expIndex))
+        }
+
+        override def visitFloat64(d: Double): Any = {
+          key = d.toString
+          wrap(this.delegate.visitFloat64(d))
+        }
+
+        override def visitFloat32(d: Float): Any = {
+          key = d.toString
+          wrap(this.delegate.visitFloat32(d))
+        }
+
+        override def visitUInt64(ul: Long): Any = {
+          key = java.lang.Long.toUnsignedString(ul)
+          wrap(this.delegate.visitUInt64(ul))
+        }
+
+        override def visitFloat64String(s: String): Any = {
+          key = s.toString
+          wrap(this.delegate.visitFloat64String(s))
+        }
+
+        override def visitChar(c: Char): Any = {
+          key = c.toString
+          wrap(this.delegate.visitChar(c))
+        }
+
+        override def visitBinary(bytes: Array[Byte], offset: Int, len: Int): Any = {
+          key = {
+            val arr = if (offset > 0 || len < bytes.length) {
+              bytes.slice(offset, offset + len)
+            } else {
+              bytes
+            }
+            Base64.getEncoder.encodeToString(arr)
+          }
+          wrap(this.delegate.visitBinary(bytes, offset, len))
         }
       }
 

--- a/weejson/jackson/src/com/rallyhealth/weejson/v1/jackson/JsonGeneratorVisitor.scala
+++ b/weejson/jackson/src/com/rallyhealth/weejson/v1/jackson/JsonGeneratorVisitor.scala
@@ -1,7 +1,10 @@
 package com.rallyhealth.weejson.v1.jackson
 
+import java.time.Instant
+import java.util.Base64
+
 import com.fasterxml.jackson.core.JsonGenerator
-import com.rallyhealth.weepickle.v1.core.{ArrVisitor, JsVisitor, ObjVisitor, SimpleVisitor, Visitor}
+import com.rallyhealth.weepickle.v1.core._
 
 /**
   * See [[JsonRenderer]] for high level use.
@@ -27,6 +30,84 @@ class JsonGeneratorVisitor(
 
     override def visitString(cs: CharSequence): JsonGenerator = {
       generator.writeFieldName(cs.toString)
+      generator
+    }
+
+    override def visitInt32(i: Int): JsonGenerator = {
+      generator.writeFieldId(i)
+      generator
+    }
+
+    override def visitInt64(l: Long): JsonGenerator = {
+      generator.writeFieldId(l)
+      generator
+    }
+
+    override def visitFloat64StringParts(
+      cs: CharSequence,
+      decIndex: Int,
+      expIndex: Int
+    ): JsonGenerator = {
+      generator.writeFieldName(cs.toString)
+      generator
+    }
+
+    override def visitTrue(): JsonGenerator = {
+      generator.writeFieldName("true")
+      generator
+    }
+
+    override def visitFalse(): JsonGenerator = {
+      generator.writeFieldName("false")
+      generator
+    }
+
+    override def visitFloat64(d: Double): JsonGenerator = {
+      generator.writeFieldName(d.toString)
+      generator
+    }
+
+    override def visitFloat32(d: Float): JsonGenerator = {
+      generator.writeFieldName(d.toString)
+      generator
+    }
+
+    override def visitUInt64(ul: Long): JsonGenerator = {
+      if (ul < 0) {
+        generator.writeFieldName(java.lang.Long.toUnsignedString(ul))
+      } else {
+        generator.writeFieldId(ul)
+      }
+      generator
+    }
+
+    override def visitFloat64String(s: String): JsonGenerator = {
+      generator.writeFieldName(s)
+      generator
+    }
+
+    override def visitTimestamp(instant: Instant): JsonGenerator = {
+      generator.writeFieldName(instant.toString)
+      generator
+    }
+
+    override def visitChar(c: Char): JsonGenerator = {
+      generator.writeFieldName(c.toString)
+      generator
+    }
+
+    override def visitBinary(
+      bytes: Array[Byte],
+      offset: Int,
+      len: Int
+    ): JsonGenerator = {
+      val arr = if (offset > 0 || len < bytes.length) {
+        bytes.slice(offset, offset + len)
+      } else {
+        bytes
+      }
+      val base64 = Base64.getEncoder.encodeToString(arr)
+      generator.writeFieldName(base64)
       generator
     }
   }

--- a/weepickle/test/src/com/rallyhealth/weepickle/v1/StructTests.scala
+++ b/weepickle/test/src/com/rallyhealth/weepickle/v1/StructTests.scala
@@ -1,6 +1,7 @@
 package com.rallyhealth.weepickle.v1
 
 import java.io.ByteArrayOutputStream
+import java.time.Instant
 
 import utest._
 
@@ -106,7 +107,45 @@ object StructTests extends TestSuite {
           Map[String, List[Int]](),
           "{}"
         )
-        test("non-string key") - {
+        test("Int key") - rw(
+          Map[Int, Boolean](1 -> true),
+          """{"1":true}"""
+        )
+        test("Long key") - rw(
+          Map[Long, Boolean](1L -> true),
+          """{"1":true}"""
+        )
+        test("Double key") - rw(
+          Map[Double, Boolean](1d -> true),
+          """{"1.0":true}"""
+        )
+        test("Float key") - rw(
+          Map[Float, Boolean](1f -> true),
+          """{"1.0":true}"""
+        )
+        test("Binary key") - {
+          // rw() tests .equals() which fails for Array.
+          val scala = Map[Array[Byte], Boolean]("pony".getBytes() -> true)
+          val json = """{"cG9ueQ==":true}"""
+          FromScala(scala).transform(ToJson.string) ==> json
+
+          val scala2 = FromJson(json).transform(ToScala[Map[Array[Byte], Boolean]])
+          scala2.head._1 ==> scala.head._1
+          scala2.head._2 ==> scala.head._2
+        }
+        test("Boolean key") - rw(
+          Map[Boolean, Boolean](true -> true),
+          """{"true":true}"""
+        )
+        test("Timestamp key") - rw(
+          Map[Instant, Boolean](Instant.EPOCH -> true),
+          """{"1970-01-01T00:00:00Z":true}"""
+        )
+        test("Char key") - rw(
+          Map[Char, Boolean]('a' -> true),
+          """{"a":true}"""
+        )
+        test("AnyVal key") - {
           TestUtil.rw(Map(new StringAnyVal("a") -> 1),
             """{"a":1}"""
           )


### PR DESCRIPTION
Hooks up jackson-core's [writeFieldId(long)](https://github.com/FasterXML/jackson-core/blob/3bd4b7d4bfb1b94b81d1959e13676fa965184aca/src/main/java/com/fasterxml/jackson/core/JsonGenerator.java#L873-L885) for numeric keys. `JsonGenerator.writeFieldId` is overridden for binary formats. The default JSON implementation converts the number to a `String`. Following its lead, I've added coercion to `String` for all other primitives that have a symmetric `To[T]` that can read from `String`.

Fixes #48.

@russellremple @plokhotnyuk @BurgersMcSlopshot @adarshrhegde