### PR TITLE
Throw an exception when parsing zero tokens rather than returning null

### DIFF
--- a/weejson/jackson/src/com/rallyhealth/weejson/v1/jackson/FromJson.scala
+++ b/weejson/jackson/src/com/rallyhealth/weejson/v1/jackson/FromJson.scala
@@ -3,8 +3,9 @@ package com.rallyhealth.weejson.v1.jackson
 import java.io.{File, InputStream, Reader}
 import java.nio.file.Path
 
-import com.fasterxml.jackson.core.{JsonFactory, JsonParser}
-import com.rallyhealth.weepickle.v1.core.{CallbackVisitor, FromInput, Visitor, TransformException}
+import com.fasterxml.jackson.core.io.JsonEOFException
+import com.fasterxml.jackson.core.{JsonFactory, JsonParseException, JsonParser}
+import com.rallyhealth.weepickle.v1.core.{CallbackVisitor, FromInput, TransformException, Visitor}
 
 import scala.util.Try
 import scala.util.control.NonFatal
@@ -50,7 +51,8 @@ class JsonFromInput(parser: JsonParser) extends FromInput {
 
   override def transform[T](to: Visitor[_, T]): T = {
     if (parser.nextToken() == null) {
-      return to.visitNull()
+      // There are no tokens at all
+      throw new JsonEOFException(parser, null, "There were no tokens to parse")
     }
 
     val builder = List.newBuilder[T]

--- a/weejson/jackson/test/src/com/rallyhealth/weejson/v1/jackson/WeeJacksonSpec.scala
+++ b/weejson/jackson/test/src/com/rallyhealth/weejson/v1/jackson/WeeJacksonSpec.scala
@@ -1,7 +1,8 @@
 package com.rallyhealth.weejson.v1.jackson
 
-import java.io.StringWriter
+import java.io.{File, StringWriter}
 
+import com.fasterxml.jackson.core.io.JsonEOFException
 import com.rallyhealth.weejson.v1._
 import com.rallyhealth.weejson.v1.jackson.DefaultJsonFactory.Instance
 import org.scalactic.TypeCheckedTripleEquals
@@ -31,6 +32,15 @@ class WeeJacksonSpec
         val writer = new StringWriter()
         value.transform(JsonRenderer(Instance.createGenerator(writer)))
         writer.toString should ===(value.transform(StringRenderer()).toString)
+      }
+    }
+  }
+
+  "empty file input" - {
+    "to required" in {
+      val file = new File(getClass.getResource("/empty.json").getPath)
+      intercept[JsonEOFException] {
+        FromJson(file).transform(Value)
       }
     }
   }


### PR DESCRIPTION
As discussed when writing code like 
`FromJson(path.toFile).transform(ToScala[Something])`
It would return null if the file was empty which was different from the behavior of `Json.parse(new FileInputStream(file))` which throws on an empty file.

I couldn't find a way to have this not change the behavior in the `FromJson(path.toFile).transform(ToScala[Option[Something]])` case and continue to return None though.