### PR TITLE
VisitorJsonGenerator.getOutputContent should not throw

### DIFF
--- a/weejson/jackson/src/com/rallyhealth/weejson/v1/jackson/VisitorJsonGenerator.scala
+++ b/weejson/jackson/src/com/rallyhealth/weejson/v1/jackson/VisitorJsonGenerator.scala
@@ -203,7 +203,7 @@ class VisitorJsonGenerator[J](
 
   override def writeTree(rootNode: TreeNode): Unit = objectCodec.writeValue(this, rootNode)
 
-  override def getOutputContext: JsonStreamContext = throw notSupported
+  override def getOutputContext: JsonStreamContext = null
 
   override def flush(): Unit = ()
 


### PR DESCRIPTION
I found [something](https://github.com/elastic/elasticsearch/blob/3deebc280405ead358973f3e49e48395f39877ed/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContentGenerator.java#L454-L455) that actually uses this method. `null` is an acceptable value. Throwing is not.