### PR TITLE
SimpleVisitor should not accept visitNull()

### DIFF
--- a/core/src/com/rallyhealth/weepickle/v1/core/SimpleVisitor.scala
+++ b/core/src/com/rallyhealth/weepickle/v1/core/SimpleVisitor.scala
@@ -7,7 +7,7 @@ import java.time.Instant
   */
 trait SimpleVisitor[-T, +J] extends Visitor[T, J] {
   def expectedMsg: String
-  def visitNull(): J = null.asInstanceOf[J]
+  def visitNull(): J = throw new Abort(expectedMsg + " got null")
   def visitTrue(): J = throw new Abort(expectedMsg + " got boolean")
   def visitFalse(): J = throw new Abort(expectedMsg + " got boolean")
 

--- a/core/src/com/rallyhealth/weepickle/v1/core/Types.scala
+++ b/core/src/com/rallyhealth/weepickle/v1/core/Types.scala
@@ -114,8 +114,8 @@ trait Types { types =>
   trait From[In] {
     def narrow[K] = this.asInstanceOf[From[K]]
     def transform[Out](in: In, out: Visitor[_, Out]): Out = {
-      if (in == null) out.visitNull()
-      else transform0(in, out)
+      if (in == null) throw new NullPointerException()
+      transform0(in, out)
     }
     def transform0[Out](in: In, out: Visitor[_, Out]): Out
     def comapNulls[U](f: U => In) = new From.MapFromNulls[U, In](this, f)

--- a/weepickle/test/src/com/rallyhealth/weepickle/v1/PrimitiveTests.scala
+++ b/weepickle/test/src/com/rallyhealth/weepickle/v1/PrimitiveTests.scala
@@ -29,7 +29,7 @@ object PrimitiveTests extends TestSuite {
         FromJson("\"\\u53c9\\u70e7\\u5305\"").transform(ToScala[String]) ==> "叉烧包"
         FromJson("\"叉烧包\"").transform(ToScala[String]) ==> "叉烧包"
       }
-      test("null") - rw(null: String, "null")
+      test("null") - rwNull(null: String, "null")
       test("chars") {
         for (i <- Char.MinValue until 55296 /*Char.MaxValue*/ ) {
           rw(i.toString)
@@ -42,7 +42,7 @@ object PrimitiveTests extends TestSuite {
         com.rallyhealth.weepickle.v1.WeePickle.FromSymbol
       )
       test("unicode") - rw('叉烧包, """ "叉烧包" """)
-      test("null") - rw(null: Symbol, "null")
+      test("null") - rwNull(null: Symbol, "null")
     }
     test("Long") {
       test("small") - rw(1: Long, """ "1" """)
@@ -61,7 +61,7 @@ object PrimitiveTests extends TestSuite {
         BigInt("23420744098430230498023841234712512315423127402740234"),
         """ "23420744098430230498023841234712512315423127402740234" """
       )
-      test("null") - rw(null: BigInt, "null")
+      test("null") - rwNull(null: BigInt, "null")
       test("abuse cases") {
         test("10k digits") - parses[BigInt](s""" "1${"0" * 9999}" """)
         test("100k digits") - assertNumberFormatException[BigInt](s""" "1${"0" * 99999}" """)
@@ -75,7 +75,7 @@ object PrimitiveTests extends TestSuite {
         BigDecimal("234207440984302304980238412.15423127402740234"),
         """ "234207440984302304980238412.15423127402740234" """
       )
-      test("null") - rw(null: BigDecimal, "null")
+      test("null") - rwNull(null: BigDecimal, "null")
       test("json integer") - {
         FromJson("123").transform(ToScala[BigDecimal]) ==> BigDecimal(123)
       }

--- a/weepickle/test/src/com/rallyhealth/weepickle/v1/TestUtil.scala
+++ b/weepickle/test/src/com/rallyhealth/weepickle/v1/TestUtil.scala
@@ -5,6 +5,8 @@ import com.rallyhealth.weejson.v1.jackson.{FromJson, ToJson}
 import com.rallyhealth.weepack.v1.{FromMsgPack, ToMsgPack}
 import com.rallyhealth.weepickle.v1.WeePickle.{FromScala, ToScala}
 
+import scala.util.Try
+
 /**
   * Created by haoyi on 4/22/14.
   */
@@ -56,6 +58,15 @@ class TestUtil[Api <: com.rallyhealth.weepickle.v1.Api](val api: Api) {
       val writtenBinaryStr = com.rallyhealth.weepickle.v1.core.TestUtil.bytesToString(writtenBinary)
       val rewrittenBinaryStr = com.rallyhealth.weepickle.v1.core.TestUtil.bytesToString(rewrittenBinary)
       assert(writtenBinaryStr == rewrittenBinaryStr)
+    }
+  }
+
+  def rwNull[T: api.To: api.From](t: T, s: String) = {
+    intercept[Exception] {
+      FromJson(s).transform(api.to[T])
+    }
+    intercept[Exception] {
+      api.from[T].transform(t, ToJson.string)
     }
   }
 


### PR DESCRIPTION
This behavior seems undesirable:

```
import com.rallyhealth.weepickle.v1.WeePickle._
import play.api.libs.json.Json

case class Foo(s: String)
object Foo {
  implicit val format = Json.format[Foo]
  implicit val rw = WeePickle.macroFromTo[Foo]
}
val json = "null"
Json.parse(json).validate[Foo] // JsError(List((/s,List(ValidationError(List(error.path.missing),WrappedArray())))))
FromJson(json).transform(ToScala[Foo]) // null ?!
```