### PR TITLE
Optimize PlayJson for mem usage.

### DIFF
--- a/weejson/play/src/com/rallyhealth/weejson/v1/play/PlayJson.scala
+++ b/weejson/play/src/com/rallyhealth/weejson/v1/play/PlayJson.scala
@@ -97,7 +97,7 @@ class PlayJson extends com.rallyhealth.weejson.v1.AstTransformer[JsValue] {
   def visitString(cs: CharSequence): JsValue = JsString(cs.toString)
 
   implicit val FromJsValue: From[JsValue] = new From[JsValue] {
-    def transform0[Out](in: JsValue, out: Visitor[_, Out]): Out = PlayJson.transform(in, out)
+    def transform0[Out](in: JsValue, out: Visitor[_, Out]): Out = PlayJson.this.transform(in, out)
   }
 
   implicit val ToJsValue: To[JsValue] = new To.Delegate[JsValue, JsValue](this)

--- a/weejson/play/src/com/rallyhealth/weejson/v1/play/PlayJson.scala
+++ b/weejson/play/src/com/rallyhealth/weejson/v1/play/PlayJson.scala
@@ -11,16 +11,14 @@ import scala.jdk.CollectionConverters._
 object PlayJson extends PlayJson
 
 class PlayJson extends com.rallyhealth.weejson.v1.AstTransformer[JsValue] {
-
   def transform[T](i: JsValue, to: Visitor[_, T]): T = i match {
-    case JsArray(xs) => transformArray(to, xs)
-    case JsBoolean(b) => if (b) to.visitTrue() else to.visitFalse()
-    case JsNull => to.visitNull()
-    case JsNumber(d) => to.visitFloat64String(d.toString)
+    case JsArray(xs)   => transformArray(to, xs)
+    case JsBoolean(b)  => if (b) to.visitTrue() else to.visitFalse()
+    case JsNull        => to.visitNull()
+    case JsNumber(d)   => to.visitFloat64String(d.toString)
     case JsObject(kvs) => transformObject(to, kvs)
-    case JsString(s) => to.visitString(s)
+    case JsString(s)   => to.visitString(s)
   }
-
   def visitArray(length: Int): ArrVisitor[JsValue, JsValue] = new AstArrVisitor[Array](JsArray(_))
 
   def visitObject(
@@ -51,15 +49,11 @@ class PlayJson extends com.rallyhealth.weejson.v1.AstTransformer[JsValue] {
     JsNumber(BigDecimal(cs.toString))
   }
 
-  override def visitFloat64(
-    d: Double
-  ): JsValue = {
+  override def visitFloat64(d: Double): JsValue = {
     JsNumber(WeePickle.ToBigDecimal.visitFloat64(d))
   }
 
-  override def visitInt64(
-    l: Long
-  ): JsValue = {
+  override def visitInt64(l: Long): JsValue = {
     JsNumber(WeePickle.ToBigDecimal.visitInt64(l))
   }
 

--- a/weejson/play/src/com/rallyhealth/weejson/v1/play/PlayJson.scala
+++ b/weejson/play/src/com/rallyhealth/weejson/v1/play/PlayJson.scala
@@ -1,12 +1,18 @@
 package com.rallyhealth.weejson.v1.play
 
-import play.api.libs.json._
-import com.rallyhealth.weepickle.v1.core.{ArrVisitor, ObjVisitor, Visitor}
+import com.rallyhealth.weepickle.v1.WeePickle
 import com.rallyhealth.weepickle.v1.WeePickle._
+import com.rallyhealth.weepickle.v1.core.{ArrVisitor, ObjVisitor, Visitor}
+import play.api.libs.json._
 
+import java.util.{LinkedHashMap => JLinkedHashMap}
+import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
+import scala.jdk.CollectionConverters._
 
-object PlayJson extends com.rallyhealth.weejson.v1.AstTransformer[JsValue] {
+object PlayJson extends PlayJson
+
+class PlayJson extends com.rallyhealth.weejson.v1.AstTransformer[JsValue] {
   def transform[T](i: JsValue, to: Visitor[_, T]): T = i match {
     case JsArray(xs)   => transformArray(to, xs)
     case JsBoolean(b)  => if (b) to.visitTrue() else to.visitFalse()
@@ -17,18 +23,76 @@ object PlayJson extends com.rallyhealth.weejson.v1.AstTransformer[JsValue] {
   }
   def visitArray(length: Int): ArrVisitor[JsValue, JsValue] = new AstArrVisitor[Array](JsArray(_))
 
-  def visitObject(length: Int): ObjVisitor[JsValue, JsValue] =
-    new AstObjVisitor[ArrayBuffer[(String, JsValue)]](JsObject(_))
+  def visitObject(
+    length: Int
+  ): ObjVisitor[JsValue, JsValue] =
+    new AstObjVisitor[ArrayBuffer[(String, JsValue)]](
+      buf => {
+        // Goals:
+        // 1. resist DoS.
+        // 2. preserve ordering like JsObject does
+        // 3. minimize heap usage.
+
+        // ignore length because it's probably -1 for JSON.
+        // Intermediate ArrayBuffer is slightly wasteful, but simple for determining length upfront.
+        // Future optimization: handle all this incrementally in a Factory?
+        val size = buf.size
+        val map = if (size <= 4) {
+
+          /**
+            * ordered and optimal up to size 4
+            * https://github.com/AudaxHealthInc/lib-stream-util/pull/19
+            */
+          buf.toMap
+        } else if (size < 100) {
+
+          /**
+            * scala.LHM is decent up to size 100, but then DoS collisions become painful.
+            *
+            * https://github.com/scala/bug/issues/11203
+            * https://github.com/playframework/play-json/issues/186
+            * https://github.com/spray/spray-json/issues/277
+            */
+          val lhm = mutable.LinkedHashMap[String, JsValue]()
+          lhm.sizeHint(buf.length)
+          lhm ++= buf
+        } else {
+
+          /**
+            * java.LHM has the DoS mitigations, but uses most heap.
+            * https://github.com/AudaxHealthInc/lib-stream-util/pull/19
+            */
+          val jlhm = new JLinkedHashMap[String, JsValue](size).asScala
+          jlhm ++= buf
+          jlhm
+        }
+        new JsObject(map)
+      }
+    )
+
 
   def visitNull(): JsValue = JsNull
 
-  def visitFalse(): JsValue = JsBoolean(false)
+  val visitFalse: JsValue = JsBoolean(false)
 
-  def visitTrue(): JsValue = JsBoolean(true)
+  val visitTrue: JsValue = JsBoolean(true)
 
   def visitFloat64StringParts(cs: CharSequence, decIndex: Int, expIndex: Int): JsValue = {
     JsNumber(BigDecimal(cs.toString))
   }
+
+  override def visitFloat64(
+    d: Double
+  ): JsValue = {
+    JsNumber(WeePickle.ToBigDecimal.visitFloat64(d))
+  }
+
+  override def visitInt64(
+    l: Long
+  ): JsValue = {
+    JsNumber(WeePickle.ToBigDecimal.visitInt64(l))
+  }
+
 
   def visitString(cs: CharSequence): JsValue = JsString(cs.toString)
 

--- a/weejson/play/src/com/rallyhealth/weejson/v1/play/UnorderedPlayJson.scala
+++ b/weejson/play/src/com/rallyhealth/weejson/v1/play/UnorderedPlayJson.scala
@@ -1,0 +1,32 @@
+package com.rallyhealth.weejson.v1.play
+
+import com.rallyhealth.weepickle.v1.core.ObjVisitor
+import play.api.libs.json._
+
+import scala.collection.immutable.TreeMap
+import scala.collection.mutable.ArrayBuffer
+
+object UnorderedPlayJson extends UnorderedPlayJson
+
+/**
+  * Uses ~0.6x of the heap of [[PlayJson]] in exchange for undefined order of JsObject keys.
+  * Ideal for {{{jsValue.as[T]}}} where order is irrelevant.
+  *
+  * Heap usage for https://rally-connect-non-prod.s3.amazonaws.com/chop-shop/test-data/labcorp.json.xz:
+  *  - 814 MB:   `Array[Byte]`
+  *  - 5,629 MB: `play.Json.parse()`
+  *  - 5,243 MB: `FromJson().transform(PlayJson)` (`java.util.LinkedHashMap` initialCapacity=2)
+  *  - 3,355 MB: `FromJson().transform(UnorderedPlayJson)` (`Map1-4` + `TreeMap`)
+  */
+class UnorderedPlayJson extends PlayJson {
+
+  override def visitObject(length: Int): ObjVisitor[JsValue, JsValue] = {
+    new AstObjVisitor[ArrayBuffer[(String, JsValue)]](toJsObject)
+  }
+
+  private def toJsObject(buf: ArrayBuffer[(String, JsValue)]) = {
+    val map = if (buf.size <= 4) buf.toMap
+    else (TreeMap.newBuilder[String, JsValue] ++= buf).result()
+    JsObject(map)
+  }
+}


### PR DESCRIPTION
I'd like to be able to extend `PlayJson` to create a variant with a memoized `hashCode`. This will let me deduplicate nodes in the tree to save heap usage on duplication-heavy json texts.