### PR TITLE
Fix Limitations link in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -316,7 +316,7 @@ GeneratorBench.smile           thrpt   15  306.462 ±  3.134  ops/s
 
 ## Limitations
 - ScalaJS is not supported (jackson-core is java-only)
-- Same macro limitations as [uPickle](http://www.lihaoyi.com/upickle/#Limitations)
+- Same macro limitations as [uPickle](https://com-lihaoyi.github.io/upickle/#Limitations)
 - XML support is still rudimentary and contributions are welcome.
 
 ## Developing


### PR DESCRIPTION
as title says.
previous goes to
<img width="874" alt="Screen Shot 2021-03-26 at 10 55 45 AM" src="https://user-images.githubusercontent.com/12701325/112673363-dbf0fa00-8e21-11eb-89eb-9326198f7a6e.png">

links to https://com-lihaoyi.github.io/upickle/#Limitations now