### PR TITLE
Throw error on unexpected nulls for SimpleVisitor

### DIFF
--- a/differences.md
+++ b/differences.md
@@ -16,7 +16,7 @@ case class Dflt(i: Int = 0)
 
 play-json always writes a `"key":"value"` pair regardless of whether it's the case class default value or not.
 
-weepickle works [differently](http://www.lihaoyi.com/upickle/#Defaults). If a field is missing upon deserialization, weepickle uses the default value if one exists. If a field at serialization time has the same value as the default, weepickle leaves it out of the serialized blob.
+weepickle works [differently](https://com-lihaoyi.github.io/upickle/#Defaults). If a field is missing upon deserialization, weepickle uses the default value if one exists. If a field at serialization time has the same value as the default, weepickle leaves it out of the serialized blob.
 
 OpenAPI 3 [has support](https://swagger.io/specification/#schemaObject) for dropping defaults:
 

--- a/readme.md
+++ b/readme.md
@@ -262,7 +262,7 @@ Internally, jackson-core uses buffer pooling to achieve some of its performance.
 `FromJson` doesn't trust you and calls `close()` automatically after writing a single [json text](https://tools.ietf.org/html/rfc7159#section-2), which covers the vast majority of use cases. If you're working with multiple json texts separated by whitespace, jackson can handle it, but you have to drop down below the high level API and remember to close the parser/generator yourself.
 
 ## Value AST
-WeePickle includes its own AST named `Value`, largely unchanged from the upstream [uJson](http://www.lihaoyi.com/upickle/#uJson).
+WeePickle includes its own AST named `Value`, largely unchanged from the upstream [uJson](https://com-lihaoyi.github.io/upickle/#uJson).
 
 ```scala
 val obj = Obj(
@@ -289,11 +289,11 @@ FromJson("""{"foo":[42,"omg",true]}""").transform(Value) ==> obj
 ```
 
 See:
-- http://www.lihaoyi.com/upickle/#uJson
+- https://com-lihaoyi.github.io/upickle/#uJson
 - http://www.lihaoyi.com/post/uJsonfastflexibleandintuitiveJSONforScala.html
 
 ## MessagePack
-weePack is weePickle's [MessagePack](https://msgpack.org/index.html) implementation, largely unchanged from the upstream [uPack](http://www.lihaoyi.com/upickle/#uPack).
+weePack is weePickle's [MessagePack](https://msgpack.org/index.html) implementation, largely unchanged from the upstream [uPack](https://com-lihaoyi.github.io/upickle/#uPack).
 
 ### sbt
 ```scala

--- a/readme.md
+++ b/readme.md
@@ -293,19 +293,15 @@ See:
 - http://www.lihaoyi.com/post/uJsonfastflexibleandintuitiveJSONforScala.html
 
 ## Null Handling
+
 In JSON, `null` ["represents the intentional absence of any object value"](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/null).
 This value is regularly used and must be supported.
 Scala also has a `null` value, but the usage is strongly discouraged, in part because it subverts the type system
 For example,
-```bash
-@ case class User(name: String)
-defined class User
-
-@ val user = User(null)
-user: User = User(null)
-
-@ user.name
-res6: String = null
+```scala
+case class User(name: String)
+val user = User(null)
+user.name // value is null
 ```
 The more equivalent value in Scala is `None`.
 Therefore, to support reading in JSON `nulls`, set the type to `Option`.

--- a/readme.md
+++ b/readme.md
@@ -292,6 +292,35 @@ See:
 - https://com-lihaoyi.github.io/upickle/#uJson
 - http://www.lihaoyi.com/post/uJsonfastflexibleandintuitiveJSONforScala.html
 
+## Null Handling
+In JSON, `null` ["represents the intentional absence of any object value"](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/null).
+This value is regularly used and must be supported.
+Scala also has a `null` value, but the usage is strongly discouraged, in part because it subverts the type system
+For example,
+```bash
+@ case class User(name: String)
+defined class User
+
+@ val user = User(null)
+user: User = User(null)
+
+@ user.name
+res6: String = null
+```
+The more equivalent value in Scala is `None`.
+Therefore, to support reading in JSON `nulls`, set the type to `Option`.
+This implies that there are two ways for an `Option` field to result in a `None` value:
+1. The value was a JSON `null`
+1. The value was missing
+
+Writing a None to JSON will cause the field to be omitted, resulting in an asymmetric read/write.
+```scala
+case class User(name: Option[String])
+
+FromJson("""{"name": null}""").transform(ToScala[User]) ==> User(None)
+FromScala(User(None)).transform(ToJson.string) ==> "{}"
+```
+
 ## MessagePack
 weePack is weePickle's [MessagePack](https://msgpack.org/index.html) implementation, largely unchanged from the upstream [uPack](https://com-lihaoyi.github.io/upickle/#uPack).
 

--- a/weepickle-core/src/main/scala/com/rallyhealth/weepickle/v1/core/SimpleVisitor.scala
+++ b/weepickle-core/src/main/scala/com/rallyhealth/weepickle/v1/core/SimpleVisitor.scala
@@ -7,7 +7,7 @@ import java.time.Instant
   */
 trait SimpleVisitor[-T, +J] extends Visitor[T, J] {
   def expectedMsg: String
-  def visitNull(): J = null.asInstanceOf[J]
+  def visitNull(): J = throw new Abort(expectedMsg + " got null")
   def visitTrue(): J = throw new Abort(expectedMsg + " got boolean")
   def visitFalse(): J = throw new Abort(expectedMsg + " got boolean")
 

--- a/weepickle-implicits/src/main/scala/com/rallyhealth/weepickle/v1/implicits/MacroImplicits.scala
+++ b/weepickle-implicits/src/main/scala/com/rallyhealth/weepickle/v1/implicits/MacroImplicits.scala
@@ -218,7 +218,7 @@ private object MacroImplicits {
           s"The referenced trait [[${clsSymbol.name}]] does not have any sub-classes. This may " +
             "happen due to a limitation of scalac (SI-7046). To work around this, " +
             "try manually specifying the sealed trait picklers as described in " +
-            "http://www.lihaoyi.com/upickle/#ManualSealedTraitPicklers"
+            "https://com-lihaoyi.github.io/upickle/#ManualSealedTraitPicklers"
         fail(tpe, msg)
       } else {
         val subTypes = fleshedOutSubtypes(tpe).toSeq

--- a/weepickle-implicits/src/main/scala/com/rallyhealth/weepickle/v1/implicits/key.scala
+++ b/weepickle-implicits/src/main/scala/com/rallyhealth/weepickle/v1/implicits/key.scala
@@ -7,6 +7,6 @@ import scala.annotation.StaticAnnotation
   * 1. subclasses to override [[discriminator]] values (default: FQCN)
   * 2. class fields to override field name.
   *
-  * @see http://www.lihaoyi.com/upickle/#CustomKeys
+  * @see https://com-lihaoyi.github.io/upickle/#CustomKeys
   */
 case class key(s: String) extends StaticAnnotation

--- a/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/DefaultsTests.scala
+++ b/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/DefaultsTests.scala
@@ -63,11 +63,9 @@ object StringTests extends TestSuite {
   implicit val pickler = WeePickle.macroFromTo[A]
 
   override val tests: Tests = Tests {
-    test("write default")(FromScala(A(null)).transform(ToJson.string) ==> """{"d":null}""")
     test("write non-default")(FromScala(A("omg")).transform(ToJson.string) ==> """{"d":"omg"}""")
-    test("write null")(FromScala(A(null)).transform(ToJson.string) ==> """{"d":null}""")
     test("read missing")(intercept[Exception](FromJson("{}").transform(ToScala[A])))
-    test("read null")(FromJson("""{"d":null}""").transform(ToScala[A]) ==> A(null))
+    test("read null")(intercept[Exception](FromJson("""{"d":null}""").transform(ToScala[A])))
   }
 }
 object StringTopDropDefaultTests extends TestSuite {
@@ -77,9 +75,8 @@ object StringTopDropDefaultTests extends TestSuite {
 
   override val tests: Tests = Tests {
     test("write non-default")(FromScala(A("omg")).transform(ToJson.string) ==> """{"d":"omg"}""")
-    test("write null")(FromScala(A(null)).transform(ToJson.string) ==> """{"d":null}""")
     test("read missing")(intercept[Exception](FromJson("{}").transform(ToScala[A])))
-    test("read null")(FromJson("""{"d":null}""").transform(ToScala[A]) ==> A(null))
+    test("read null")(intercept[Exception](FromJson("""{"d":null}""").transform(ToScala[A])))
   }
 }
 
@@ -91,10 +88,9 @@ object DefaultStringTopDropDefaultTests extends TestSuite {
   override val tests: Tests = Tests {
     test("write default")(FromScala(A()).transform(ToJson.string) ==> """{}""")
     test("write non-default")(FromScala(A("omg")).transform(ToJson.string) ==> """{"d":"omg"}""")
-    test("write null")(FromScala(A(null)).transform(ToJson.string) ==> """{"d":null}""")
     test("read missing")(FromJson("""{}""").transform(ToScala[A]) ==> A("lol"))
     test("read present")(FromJson("""{"d":"omg"}""").transform(ToScala[A]) ==> A("omg"))
-    test("read null")(FromJson("""{"d":null}""").transform(ToScala[A]) ==> A(null))
+    test("read null")(intercept[Exception](FromJson("""{"d":null}""").transform(ToScala[A])))
   }
 }
 
@@ -106,7 +102,7 @@ object OptionTopDropDefaultTests extends TestSuite {
   override val tests: Tests = Tests {
     test("write default")(FromScala(A()).transform(ToJson.string) ==> """{}""")
     test("write non-default")(FromScala(A(Some("omg"))).transform(ToJson.string) ==> """{"d":"omg"}""")
-    test("write null")(FromScala(A(null)).transform(ToJson.string) ==> """{"d":null}""")
+    test("write empty")(FromScala(A(None)).transform(ToJson.string) ==> """{}""")
     test("read missing")(FromJson("{}").transform(ToScala[A]) ==> A(None))
     test("read null")(FromJson("""{"d":null}""").transform(ToScala[A]) ==> A(None))
   }

--- a/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/DefaultsTests.scala
+++ b/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/DefaultsTests.scala
@@ -64,6 +64,7 @@ object StringTests extends TestSuite {
 
   override val tests: Tests = Tests {
     test("write non-default")(FromScala(A("omg")).transform(ToJson.string) ==> """{"d":"omg"}""")
+    test("write null")(FromScala(A(null)).transform(ToJson.string) ==> """{"d":null}""")
     test("read missing")(intercept[Exception](FromJson("{}").transform(ToScala[A])))
     test("read null")(intercept[Exception](FromJson("""{"d":null}""").transform(ToScala[A])))
   }
@@ -75,6 +76,7 @@ object StringTopDropDefaultTests extends TestSuite {
 
   override val tests: Tests = Tests {
     test("write non-default")(FromScala(A("omg")).transform(ToJson.string) ==> """{"d":"omg"}""")
+    test("write null")(FromScala(A(null)).transform(ToJson.string) ==> """{"d":null}""")
     test("read missing")(intercept[Exception](FromJson("{}").transform(ToScala[A])))
     test("read null")(intercept[Exception](FromJson("""{"d":null}""").transform(ToScala[A])))
   }
@@ -88,6 +90,7 @@ object DefaultStringTopDropDefaultTests extends TestSuite {
   override val tests: Tests = Tests {
     test("write default")(FromScala(A()).transform(ToJson.string) ==> """{}""")
     test("write non-default")(FromScala(A("omg")).transform(ToJson.string) ==> """{"d":"omg"}""")
+    test("write null")(FromScala(A(null)).transform(ToJson.string) ==> """{"d":null}""")
     test("read missing")(FromJson("""{}""").transform(ToScala[A]) ==> A("lol"))
     test("read present")(FromJson("""{"d":"omg"}""").transform(ToScala[A]) ==> A("omg"))
     test("read null")(intercept[Exception](FromJson("""{"d":null}""").transform(ToScala[A])))

--- a/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/PrimitiveTests.scala
+++ b/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/PrimitiveTests.scala
@@ -29,7 +29,7 @@ object PrimitiveTests extends TestSuite {
         FromJson("\"\\u53c9\\u70e7\\u5305\"").transform(ToScala[String]) ==> "叉烧包"
         FromJson("\"叉烧包\"").transform(ToScala[String]) ==> "叉烧包"
       }
-      test("null") - rw(null: String, "null")
+      test("null") - rwNull(null: String, "null")
       test("chars") {
         for (i <- Char.MinValue until 55296 /*Char.MaxValue*/ ) {
           rw(i.toString)
@@ -42,7 +42,7 @@ object PrimitiveTests extends TestSuite {
         com.rallyhealth.weepickle.v1.WeePickle.FromSymbol
       )
       test("unicode") - rw('叉烧包, """ "叉烧包" """)
-      test("null") - rw(null: Symbol, "null")
+      test("null") - rwNull(null: Symbol, "null")
     }
     test("Long") {
       test("small") - rw(1: Long, """ "1" """)
@@ -61,7 +61,7 @@ object PrimitiveTests extends TestSuite {
         BigInt("23420744098430230498023841234712512315423127402740234"),
         """ "23420744098430230498023841234712512315423127402740234" """
       )
-      test("null") - rw(null: BigInt, "null")
+      test("null") - rwNull(null: BigInt, "null")
       test("abuse cases") {
         test("10k digits") - parses[BigInt](s""" "1${"0" * 9999}" """)
         test("100k digits") - assertNumberFormatException[BigInt](s""" "1${"0" * 99999}" """)
@@ -75,7 +75,7 @@ object PrimitiveTests extends TestSuite {
         BigDecimal("234207440984302304980238412.15423127402740234"),
         """ "234207440984302304980238412.15423127402740234" """
       )
-      test("null") - rw(null: BigDecimal, "null")
+      test("null") - rwNull(null: BigDecimal, "null")
       test("json integer") - {
         FromJson("123").transform(ToScala[BigDecimal]) ==> BigDecimal(123)
       }

--- a/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/StructTests.scala
+++ b/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/StructTests.scala
@@ -28,12 +28,12 @@ object StructTests extends TestSuite {
       test("Boolean") - rwk(Array(true, false), "[true,false]")(_.toSeq)
       test("Int") - rwk(Array(1, 2, 3, 4, 5), "[1,2,3,4,5]")(_.toSeq)
       test("String") - rwk(Array("omg", "i am", "cow"), """["omg","i am","cow"]""")(_.toSeq)
-      test("Nulls") - rwk(Array(null, "i am", null), """[null,"i am",null]""")(_.toSeq)
+      test("Nulls") - rwNull(Array(null, "i am", null), """[null,"i am",null]""")
 
     }
 
     test("tuples") {
-      test("null") - rw(null: Tuple2[Int, Int], "null")
+      test("null") - rwNull(null: Tuple2[Int, Int], "null")
       "2" - rw((1, 2, 3.0), "[1,2,3.0]", "[1,2,3]")
       "2-1" - rw((false, 1), "[false,1]")
       "3" - rw(("omg", 1, "bbq"), """["omg",1,"bbq"]""")

--- a/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/TestUtil.scala
+++ b/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/TestUtil.scala
@@ -59,6 +59,13 @@ class TestUtil[Api <: com.rallyhealth.weepickle.v1.Api](val api: Api) {
     }
   }
 
+  def rwNull[T: api.To: api.From](t: T, s: String) = {
+    intercept[Exception] {
+      FromJson(s).transform(api.to[T])
+      api.from[T].transform(t, ToJson.string)
+    }
+  }
+
   def roundTripMsgPack[T: WeePickle.From: WeePickle.To](in: T) = {
     val msgPack = FromScala(in).transform(ToMsgPack.bytes)
     val roundTripped = FromMsgPack(msgPack).transform(ToScala[T])

--- a/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/TestUtil.scala
+++ b/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/TestUtil.scala
@@ -62,8 +62,8 @@ class TestUtil[Api <: com.rallyhealth.weepickle.v1.Api](val api: Api) {
   def rwNull[T: api.To: api.From](t: T, s: String) = {
     intercept[Exception] {
       FromJson(s).transform(api.to[T])
-      api.from[T].transform(t, ToJson.string)
     }
+    api.from[T].transform(t, ToJson.string)
   }
 
   def roundTripMsgPack[T: WeePickle.From: WeePickle.To](in: T) = {

--- a/weepickle/src/main/scala/com/rallyhealth/weepickle/v1/Api.scala
+++ b/weepickle/src/main/scala/com/rallyhealth/weepickle/v1/Api.scala
@@ -52,7 +52,7 @@ object Api {
       * Transforms object keys.
       * e.g. {"food_group": "vegetable"} => {"FoodGroup": "vegetable"}
       *
-      * @see http://www.lihaoyi.com/upickle/#CustomConfiguration
+      * @see https://com-lihaoyi.github.io/upickle/#CustomConfiguration
       */
     def objectAttributeKeyReadMap(s: CharSequence): CharSequence = s
     def objectAttributeKeyWriteMap(s: CharSequence): CharSequence = s
@@ -63,7 +63,7 @@ object Api {
       *    {"\$type": "com.rallyhealth.Bee"} => {"\$type": "com-rallyhealth-bee"}
       * }}}
       *
-      * @see http://www.lihaoyi.com/upickle/#CustomConfiguration
+      * @see https://com-lihaoyi.github.io/upickle/#CustomConfiguration
       */
     def objectTypeKeyReadMap(s: CharSequence): CharSequence = s
     def objectTypeKeyWriteMap(s: CharSequence): CharSequence = s


### PR DESCRIPTION
Picking up where https://github.com/rallyhealth/weePickle/pull/55 left off.

This PR makes it so that any non-Option types that encounter `null` will throw. Reading `null`s will require setting the data type to `Option`.

The main point of contention I imagine is the asymmetric read/write this implementation proposes:
```scala
case class User(name: Option[String])
FromJson("""{"name": null}""").transform(ToScala[User]) ==> User(None)
FromScala(User(None)).transform(ToJson.string) ==> "{}"
```

I don't think it's a problem, but I'd be curious to know other opinions.

