### PR TITLE
Include "JsonPointerException" in JsonPointerException.toString

### DIFF
--- a/weepickle-core/src/main/scala/com/rallyhealth/weepickle/v1/core/JsonPointerVisitor.scala
+++ b/weepickle-core/src/main/scala/com/rallyhealth/weepickle/v1/core/JsonPointerVisitor.scala
@@ -30,10 +30,7 @@ object JsonPointerVisitor {
     */
   class JsonPointerException(val jsonPointer: String, cause: Throwable)
       extends Exception(jsonPointer, cause)
-      with NoStackTrace {
-
-    override def toString: String = jsonPointer
-  }
+      with NoStackTrace
 
   /**
     * Internally, the paths form a linked list back to the root by the visitors themselves.


### PR DESCRIPTION
`JsonPointerException` omits its own name from `toString` leading to cryptic logged exceptions, particularly when the path is empty string.