### PR TITLE
Fix: "match may not be exhaustive" scala 2.13 -Xlint warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -205,3 +205,9 @@ lazy val weexml = project
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-xml" % "2.12.3",
     )
   )
+
+lazy val `weepickle-macro-lint-tests` = project
+  .dependsOn(weepickle)
+  .settings(noPublish)
+  .settings(scalacOptions := (scalacOptions.value ++ Seq("-Xlint", "-Xfatal-warnings")).distinct)
+//  .settings(scalacOptions += "-Ymacro-debug-lite")

--- a/weepickle-implicits/src/main/scala/com/rallyhealth/weepickle/v1/implicits/MacroImplicits.scala
+++ b/weepickle-implicits/src/main/scala/com/rallyhealth/weepickle/v1/implicits/MacroImplicits.scala
@@ -496,6 +496,7 @@ private object MacroImplicits {
             def storeAggregatedValue(currentIndex: Int, v: Any): Unit = currentIndex match{
               case ..${for (arg <- args)
         yield cq"${arg.i} => ${arg.aggregate} = v.asInstanceOf[${arg.argType}]"}
+              case _ => throw new java.lang.IndexOutOfBoundsException(currentIndex.toString)
             }
             def visitKey() = com.rallyhealth.weepickle.v1.core.StringVisitor
             def visitKeyValue(s: Any) = {
@@ -550,6 +551,8 @@ private object MacroImplicits {
                 } yield i match{
                   case ..${for (arg <- args)
         yield cq"${arg.i} => ${arg.mapped}"}
+                  case _ => throw new java.lang.IndexOutOfBoundsException(i.toString)
+
                 }
                 throw new com.rallyhealth.weepickle.v1.core.Abort(
                   "missing keys in dictionary: " + keys.mkString(", ")

--- a/weepickle-macro-lint-tests/src/main/scala/com/rallyhealth/weepickle/v1/SingleInt.scala
+++ b/weepickle-macro-lint-tests/src/main/scala/com/rallyhealth/weepickle/v1/SingleInt.scala
@@ -1,0 +1,11 @@
+package com.rallyhealth.weepickle.v1
+
+import com.rallyhealth.weepickle.v1.WeePickle.{FromTo, macroFromTo}
+
+/**
+ * @see https://github.com/com-lihaoyi/upickle/issues/345
+ */
+case class SingleInt(num: Int)
+object SingleInt {
+  implicit val pickler: FromTo[SingleInt] = macroFromTo
+}

--- a/weepickle-macro-lint-tests/src/main/scala/com/rallyhealth/weepickle/v1/readme.md
+++ b/weepickle-macro-lint-tests/src/main/scala/com/rallyhealth/weepickle/v1/readme.md
@@ -1,0 +1,1 @@
+The macro expansions of these classes should compile without any `-Xlint` errors.


### PR DESCRIPTION
Test and workaround for https://github.com/com-lihaoyi/upickle/issues/345.