### PR TITLE
Change parseLong(): len => end

### DIFF
--- a/weepickle-core/src/main/scala/com/rallyhealth/weepickle/v1/core/Util.scala
+++ b/weepickle-core/src/main/scala/com/rallyhealth/weepickle/v1/core/Util.scala
@@ -43,16 +43,15 @@ object Util {
 
     intPortion + decPortion
   }
-  def parseLong(cs: CharSequence, start: Int, len: Int): Long = {
+  def parseLong(cs: CharSequence, start: Int, end: Int): Long = {
     // we store the inverse of the positive sum, to ensure we don't
     // incorrectly overflow on Long.MinValue. for positive numbers
     // this inverse sum will be inverted before being returned.
     var inverseSum: Long = 0L
     var inverseSign: Long = -1L
     var i: Int = start
-    val end = start + len
 
-    if ((start | len | (cs.length - end) | end) < 0) throw new IndexOutOfBoundsException
+    if ((start | end | end - start | cs.length - end) < 0) throw new IndexOutOfBoundsException
 
     if (cs.charAt(start) == '-') {
       inverseSign = 1L

--- a/weepickle-core/src/test/scala/com/rallyhealth/weepickle/v1/core/UtilTests.scala
+++ b/weepickle-core/src/test/scala/com/rallyhealth/weepickle/v1/core/UtilTests.scala
@@ -29,48 +29,48 @@ class UtilTests
       "padded" in {
         forAll { (head: String, l: Long, tail: String) =>
           val s = l.toString
-          Util.parseLong(s"$head$s$tail", head.length, s.length) should ===(l)
-        }
-      }
-    }
-  }
-
-  "failures" - {
-    "strings" in {
-      forAll { (s: String) =>
-        whenever(Try(s.toLong).isFailure) {
-          assert(Try(Util.parseLong(s, 0, s.length)).isFailure)
+          Util.parseLong(s"$head$s$tail", head.length, head.length + s.length) should ===(l)
         }
       }
     }
 
-    def invalid(s: String) = {
-      assert(Try(Util.parseLong(s, 0, s.length)).isFailure)
-      assert(Try(Util.parseLong(" " + s, 1, s.length)).isFailure)
-      assert(Try(Util.parseLong(s + " ", 0, s.length)).isFailure)
-      assert(Try(Util.parseLong(" " + s + " ", 1, s.length)).isFailure)
-    }
-    "a" in invalid("a")
-    "-" in invalid("-")
-    "᥌" in invalid("᥌")
-    "too long" in invalid(Long.MaxValue.toString + "1")
-
-    "bounds" in {
-      val s = "111"
-      for {
-        start <- -1 to 5
-        len <- -1 to 5
-        if len != 0 // NFE, not IndexOutOfBoundsException
-      } {
-        withClue(s"$s, $start, $len") {
-          if (Try(s.substring(start, start + len)).isSuccess) {
-            Util.parseLong(s, start, len)
-          } else {
-            intercept[IndexOutOfBoundsException](Util.parseLong(s, start, len))
+    "failures" - {
+      "strings" in {
+        forAll { (s: String) =>
+          whenever(Try(s.toLong).isFailure) {
+            assert(Try(Util.parseLong(s, 0, s.length)).isFailure)
           }
         }
       }
 
+      def invalid(s: String) = {
+        assert(Try(Util.parseLong(s, 0, s.length)).isFailure)
+        assert(Try(Util.parseLong(" " + s, 1, 1 + s.length)).isFailure)
+        assert(Try(Util.parseLong(s + " ", 0, s.length)).isFailure)
+        assert(Try(Util.parseLong(" " + s + " ", 1, 1 + s.length)).isFailure)
+      }
+      "a" in invalid("a")
+      "-" in invalid("-")
+      "᥌" in invalid("᥌")
+      "too long" in invalid(Long.MaxValue.toString + "1")
+
+      "bounds" in {
+        val s = "111"
+        for {
+          start <- -1 to s.length + 1
+            end <- -1 to s.length + 1
+          if end != start // NFE, not IndexOutOfBoundsException
+        } {
+          withClue(s"$s, $start, $end") {
+            if (Try(s.substring(start, end)).isSuccess) {
+              Util.parseLong(s, start, end)
+            } else {
+              intercept[IndexOutOfBoundsException](Util.parseLong(s, start, end))
+            }
+          }
+        }
+
+      }
     }
   }
 }

--- a/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/FailureTests.scala
+++ b/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/FailureTests.scala
@@ -28,7 +28,7 @@ object Fi {
   */
 object FailureTests extends TestSuite {
 
-  def tests = Tests {
+  val tests = Tests {
 //    test("test"){
 //      read[com.rallyhealth.weejson.v1.Value](""" {unquoted_key: "keys must be quoted"} """)
 //    }


### PR DESCRIPTION
https://github.com/com-lihaoyi/upickle/pull/361 made me realize that the third param of `Util.parseLong` is intended to be `end`, not `len`. I didn't realize this assumption within weepickle because we don't use `Util.parseLong` for JSON parsing like upickle does.

I'm updating weepickle to be consistent to avoid any latent bugs and keep it simple to take future patches from upickle.