### PR TITLE
Add Ops

### DIFF
--- a/bench/src/main/scala/rallyhealth/weepickle/v1/CardinalityVisitor.scala
+++ b/bench/src/main/scala/rallyhealth/weepickle/v1/CardinalityVisitor.scala
@@ -1,0 +1,47 @@
+package rallyhealth.weepickle.v1
+
+import com.rallyhealth.weepickle.v1.core._
+
+/**
+  * Returns the number of elements in an array or object.
+  *
+  * Useful for benchmarks to prevent the compiler from cheating.
+  */
+class CardinalityVisitor extends SimpleVisitor[Any, Int] {
+
+  override def expectedMsg: String = "expected obj/arr"
+
+  override def visitObject(
+    length: Int
+  ): ObjVisitor[Any, Int] = new ObjVisitor[Any, Int] {
+    private var i = 0
+
+    override def visitKey(): Visitor[_, _] = NoOpVisitor
+
+    override def visitKeyValue(
+      v: Any
+    ): Unit = ()
+
+    override def subVisitor: Visitor[_, _] = NoOpVisitor
+
+    override def visitValue(
+      v: Any
+    ): Unit = i += 1
+
+    override def visitEnd(): Int = i
+  }
+
+  override def visitArray(
+    length: Int
+  ): ArrVisitor[Any, Int] = new ArrVisitor[Any, Int] {
+    private var i = 0
+
+    override def subVisitor: Visitor[_, _] = NoOpVisitor
+
+    override def visitValue(
+      v: Any
+    ): Unit = i += 1
+
+    override def visitEnd(): Int = i
+  }
+}

--- a/bench/src/main/scala/rallyhealth/weepickle/v1/core/ops/ConcatFromInputsBench.scala
+++ b/bench/src/main/scala/rallyhealth/weepickle/v1/core/ops/ConcatFromInputsBench.scala
@@ -1,0 +1,74 @@
+package rallyhealth.weepickle.v1.core.ops
+
+import com.rallyhealth.weepickle.v1.core.ops.ConcatFromInputs
+import com.rallyhealth.weepickle.v1.core.{FromInput, Visitor}
+import org.openjdk.jmh.annotations._
+import rallyhealth.weepickle.v1.CardinalityVisitor
+
+import java.util.concurrent.TimeUnit
+
+/**
+  * ==Quick Run==
+  * bench / Jmh / run -f1 -wi 2 -i 3 .*ConcatFromInputsBench
+  *
+  * ==Profile with Flight Recorder==
+  * bench / Jmh / run -prof jfr -f1 .*ConcatFromInputsBench
+  *
+  * ==Jmh Visualizer Report==
+  * bench / Jmh / run -prof gc -rf json -rff ConcatFromInputsBench-results.json .*ConcatFromInputsBench
+  *
+  * ==Sample Results==
+  * bench / Jmh / run -f3 -wi 3 -i 3 .*ConcatFromInputsBench
+  * {{{
+  * Benchmark                    Mode  Cnt   Score    Error  Units
+  * ConcatFromInputsBench.arrs  thrpt    9  96.627 ±  6.636  ops/s
+  * ConcatFromInputsBench.objs  thrpt    9  72.950 ± 13.792  ops/s
+  * }}}
+  *
+  * @see https://github.com/ktoso/sbt-jmh
+  */
+@Warmup(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(jvmArgsAppend = Array("-Xmx350m", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:-BackgroundCompilation", "-XX:-TieredCompilation"), value = 1)
+class ConcatFromInputsBench {
+
+  @Benchmark
+  def objs: Int = ConcatFromInputs.from(manyObjs).get.transform(sink)
+
+  @Benchmark
+  def arrs: Int = ConcatFromInputs.from(manyArrs).get.transform(sink)
+
+  private val manyObjs = {
+    // not using FromScala(Obj(...)) to avoid profiler noise from singleObj.size(), etc.
+    val singleObj = new FromInput {
+      override def transform[T](
+        to: Visitor[_, T]
+      ): T = {
+        val obj = to.visitObject(1).narrow
+        obj.visitKeyValue(obj.visitKey().visitString("key"))
+        obj.visitValue(obj.subVisitor.visitTrue())
+        obj.visitEnd()
+      }
+    }
+    Seq.fill(1000 * 1000)(singleObj)
+  }
+
+  private val manyArrs = {
+    // not using FromScala(Arr(...)) to avoid profiler noise from singleArr.size(), etc.
+    val singleArr = new FromInput {
+      override def transform[T](
+        to: Visitor[_, T]
+      ): T = {
+        val arr = to.visitArray(1).narrow
+        arr.visitValue(arr.subVisitor.visitTrue())
+        arr.visitEnd()
+      }
+    }
+    Seq.fill(1000 * 1000)(singleArr)
+  }
+
+  private def sink = new CardinalityVisitor
+}

--- a/bench/src/test/scala/com/rallyhealth/weepickle/v1/core/ops/ConcatFromInputsBenchTests.scala
+++ b/bench/src/test/scala/com/rallyhealth/weepickle/v1/core/ops/ConcatFromInputsBenchTests.scala
@@ -1,0 +1,12 @@
+package com.rallyhealth.weepickle.v1.core.ops
+
+import rallyhealth.weepickle.v1.core.ops.ConcatFromInputsBench
+import utest._
+
+object ConcatFromInputsBenchTests extends TestSuite {
+
+  override val tests = Tests {
+    test("objs")(new ConcatFromInputsBench().objs ==> 1000000)
+    test("arrs")(new ConcatFromInputsBench().arrs ==> 1000000)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -84,6 +84,7 @@ lazy val weepickle = project
   .dependsOn(
     `weepickle-implicits`,
     weejson,
+    `weepickle-laws` % Test,
   )
 
 /**
@@ -114,6 +115,9 @@ lazy val `weepickle-tests` = project
   */
 lazy val weejson = project
   .dependsOn(`weejson-jackson`)
+  .settings(
+    Test / scalacOptions := (Test / scalacOptions).value.filterNot(_ == "-deprecation"),
+  )
 
 lazy val weepack = project
   .dependsOn(
@@ -237,3 +241,16 @@ lazy val `weepickle-macro-lint-tests` = project
   .settings(scalacOptions := (scalacOptions.value ++ Seq("-Xlint", "-Xfatal-warnings")).distinct)
   .settings(crossScalaVersions := supportedScala2Versions) // TODO: Scala 3?
 //  .settings(scalacOptions += "-Ymacro-debug-lite")
+
+lazy val `weepickle-laws` = project
+  .dependsOn(
+    `weepickle-core`,
+    weejson % "compile;test->test",
+  )
+  .settings(
+    mimaPreviousArtifacts := (if (version.value < "1.7") Set.empty else mimaPreviousArtifacts.value),
+    libraryDependencies ++= Seq(
+      "com.lihaoyi" %% "sourcecode" % "0.2.7",
+      "org.scalacheck" %% "scalacheck" % "1.14.3" % Test,
+    ),
+  )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.9.2")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.2")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")

--- a/weejson/src/test/scala/com/rallyhealth/weejson/v1/GenValue.scala
+++ b/weejson/src/test/scala/com/rallyhealth/weejson/v1/GenValue.scala
@@ -1,7 +1,7 @@
 package com.rallyhealth.weejson.v1
 
 import com.rallyhealth.weejson.v1._
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.{Arbitrary, Gen, Shrink}
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -53,5 +53,13 @@ trait GenValue {
 
   implicit val arbNum: Arbitrary[Num] = Arbitrary {
     Arbitrary.arbitrary[Double].map(Num(_))
+  }
+
+  implicit val shrinkValue: Shrink[Value] = Shrink[Value] {
+    case Obj(map) => Shrink.shrink(map).map(Obj(_))
+    case Arr(buf) => Shrink.shrink(buf).map(Arr(_))
+    case Num(bd) => Shrink.shrink(bd).map(Num(_))
+    case Str(s) => Shrink.shrink(s).map(Str(_))
+    case _ => Stream.empty
   }
 }

--- a/weepickle-core/src/main/scala/com/rallyhealth/weepickle/v1/core/ops/ConcatFromInputs.scala
+++ b/weepickle-core/src/main/scala/com/rallyhealth/weepickle/v1/core/ops/ConcatFromInputs.scala
@@ -1,0 +1,143 @@
+package com.rallyhealth.weepickle.v1.core.ops
+
+import com.rallyhealth.weepickle.v1.core.Visitor.{ArrDelegate, ObjDelegate}
+import com.rallyhealth.weepickle.v1.core._
+import scala.collection.compat._
+
+import scala.annotation.tailrec
+
+object ConcatFromInputs {
+
+  /**
+    * Concatenates elements of one or more objects or arrays.
+    *
+    * ==Examples==
+    *   - {{{ [1] ++ [2] ==> [1, 2] }}}
+    *   - {{{ {"a": 0} ++ {"b": 1} ==> {"a": 0, "b": 1} }}}
+    *   - {{{ {"a": 0} ++ {"a": 1} ==> {"a": 0, "a": 1} }}}
+    *   - {{{ {"a": 0} ++ [false] ==> }}} [[com.rallyhealth.weepickle.v1.core.Abort]]
+    *
+    * ==Caveats==
+    * - Does not report object or array length. Will not work for msgpack.
+    */
+  def apply(
+    head: FromInput,
+    tail: FromInput*
+  ): FromInput = from(head +: tail).get
+
+  /**
+    * Concatenates elements of one or more objects or arrays.
+    *
+    * ==Examples==
+    *   - {{{ [1] ++ [2] ==> [1, 2] }}}
+    *   - {{{ {"a": 0} ++ {"b": 1} ==> {"a": 0, "b": 1} }}}
+    *   - {{{ {"a": 0} ++ {"a": 1} ==> {"a": 0, "a": 1} }}}
+    *   - {{{ {"a": 0} ++ [false] ==> }}} [[com.rallyhealth.weepickle.v1.core.Abort]]
+    *
+    * ==Caveats==
+    * - Does not report object or array length. Will not work for msgpack.
+    */
+  def from(
+    inputs: Seq[FromInput]
+  ): Option[FromInput] = {
+    if (inputs.isEmpty) None
+    else if (inputs.sizeCompare(1) == 0) Some(inputs.head)
+    else {
+      // flatten for stack safety
+      val flattened =
+        if (inputs.exists(_.isInstanceOf[ConcatFromInputs])) {
+          inputs.flatMap {
+            case c: ConcatFromInputs => c.inputs
+            case other => other :: Nil
+          }
+        } else inputs
+      Some(new ConcatFromInputs(flattened))
+    }
+  }
+
+  private[this] class ConcatFromInputs(
+    val inputs: Seq[FromInput]
+  ) extends FromInput {
+
+    assert(inputs.sizeCompare(1) > 0)
+
+    override def transform[T](
+      to: Visitor[_, T]
+    ): T = {
+      val it = inputs.iterator
+      it.next().transform {
+        new SimpleVisitor[Any, T] {
+          override def expectedMsg: String = "expected arr or obj"
+
+          override def visitObject(
+            length: Int
+          ): ObjVisitor[Any, T] = {
+            val obj = to.visitObject(-1).narrow // final length unknown
+            val nonLastObj = new ObjDelegate[Any, T](obj) {
+              override def visitEnd() = null.asInstanceOf[T]
+            }
+
+            new ObjDelegate[Any, T](obj) {
+              override def visitEnd(): T = {
+                @tailrec def transformNext(): T = {
+                  val result = it.next().transform {
+                    new SimpleVisitor[Any, T] {
+                      override def expectedMsg: String = "expected another obj"
+
+                      override def visitObject(
+                        length: Int
+                      ): ObjVisitor[Any, T] = {
+                        // suppress visitEnd if more input is coming
+                        if (it.hasNext) nonLastObj
+                        else obj
+                      }
+                    }
+                  }
+
+                  if (it.hasNext) transformNext()
+                  else result
+                }
+
+                transformNext()
+              }
+            }
+          }
+
+          override def visitArray(
+            length: Int
+          ): ArrVisitor[Any, T] = {
+            val arr = to.visitArray(-1).narrow // final length unknown
+            val nonLastArr = new ArrDelegate[Any, T](arr) {
+              override def visitEnd() = null.asInstanceOf[T]
+            }
+
+            new ArrDelegate[Any, T](arr) {
+              override def visitEnd(): T = {
+                @tailrec def transformNext(): T = {
+                  val result = it.next().transform {
+                    new SimpleVisitor[Any, T] {
+                      override def expectedMsg: String = "expected another arr"
+
+                      override def visitArray(
+                        length: Int
+                      ): ArrVisitor[Any, T] = {
+                        // suppress visitEnd if more input is coming
+                        if (it.hasNext) nonLastArr
+                        else arr
+                      }
+                    }
+                  }
+
+                  if (it.hasNext) transformNext()
+                  else result
+                }
+
+                transformNext()
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/weepickle-core/src/main/scala/com/rallyhealth/weepickle/v1/core/ops/FromInputOps.scala
+++ b/weepickle-core/src/main/scala/com/rallyhealth/weepickle/v1/core/ops/FromInputOps.scala
@@ -1,0 +1,38 @@
+package com.rallyhealth.weepickle.v1.core.ops
+
+import com.rallyhealth.weepickle.v1.core.FromInput
+
+/**
+ * Mixes extensions into bundles, e.g. WeePickle.
+ */
+trait FromInputOpsImplicits {
+
+  implicit def asFromInputOps(a: FromInput): FromInputOps = new FromInputOps(a)
+}
+
+/**
+ * Extension operations on [[FromInput]] that are part of the core API.
+ *
+ * More methods may be added here without breaking binary compatibility (which
+ * is not possible with traits).
+ */
+class FromInputOps(
+  val a: FromInput
+) extends AnyVal {
+
+  /**
+   * Concatenates elements of one or more objects or arrays.
+   *
+   * ==Examples==
+   *   - {{{ [1] ++ [2] ==> [1, 2] }}}
+   *   - {{{ {"a": 0} ++ {"b": 1} ==> {"a": 0, "b": 1} }}}
+   *   - {{{ {"a": 0} ++ {"a": 1} ==> {"a": 0, "a": 1} }}}
+   *   - {{{ {"a": 0} ++ [false] ==> }}} [[com.rallyhealth.weepickle.v1.core.Abort]]
+   *
+   * ==Caveats==
+   * - Does not report object or array length. Will not work for msgpack.
+   */
+  def ++(
+    b: FromInput
+  ): FromInput = ConcatFromInputs(a, b)
+}

--- a/weepickle-laws/src/main/scala/com/rallyhealth/weepickle/v1/laws/LawsVisitor.scala
+++ b/weepickle-laws/src/main/scala/com/rallyhealth/weepickle/v1/laws/LawsVisitor.scala
@@ -1,0 +1,393 @@
+package com.rallyhealth.weepickle.v1.laws
+
+import com.rallyhealth.weepickle.v1.core.Visitor.{ArrDelegate, ObjDelegate}
+import com.rallyhealth.weepickle.v1.core.{ArrVisitor, ObjVisitor, Visitor}
+import com.rallyhealth.weepickle.v1.laws.LawsVisitor.{ObjArrState, VisitorState}
+
+import java.time.Instant
+
+/**
+  * Enforces that all "visit" calls are made against this visitor in the correct order.
+  *
+  * ==Usage==
+  * {{{
+  *   val v = new YourVisitor(new LawsVisitor(NullVisitor))
+  *   input.transform(v)
+  * }}}
+  *
+  * All methods throw `IllegalStateException` if invoked in an invalid order.
+  */
+class LawsVisitor[T, J](
+  delegate: Visitor[T, J]
+) extends Visitor.Delegate[T, J](delegate) {
+
+  private var parentState: VisitorState.State = VisitorState.Initialized
+
+  /**
+    * Invoked on start of:
+    * - [[visitObject]]
+    * - [[visitArray]]
+    * - [[visitTrue]]
+    * - etc.
+    */
+  protected[LawsVisitor] def onValueStart(
+  )(
+    implicit
+    enc: sourcecode.Enclosing
+  ): Unit = {
+    import VisitorState._
+    parentState.assertOneOf(Initialized)
+    parentState = VisitStart
+  }
+
+  /**
+    * Invoked on completion of:
+    * - [[com.rallyhealth.weepickle.v1.core.ObjVisitor.visitEnd]]
+    * - [[com.rallyhealth.weepickle.v1.core.ArrVisitor.visitEnd]]
+    * - [[visitTrue]]
+    * - etc.
+    */
+  protected[LawsVisitor] def onValueEnd(
+  )(
+    implicit
+    enc: sourcecode.Enclosing
+  ): Unit = {
+    import VisitorState._
+    parentState.assertOneOf(VisitStart)
+    parentState = VisitComplete
+  }
+
+  /**
+    * Shortcut for eveything except [[visitObject]] and [[visitArray]].
+    */
+  protected[LawsVisitor] def onValue(
+  )(
+    implicit
+    enc: sourcecode.Enclosing
+  ): Unit = {
+    onValueStart()
+    onValueEnd()
+  }
+
+  override def close(): Unit = {
+    import VisitorState._
+    parentState.assertOneOf(VisitComplete)
+    parentState = Closed
+    super.close()
+  }
+
+  override def visitObject(
+    length: Int
+  ): ObjVisitor[T, J] = {
+    require(length >= -1, s"length $length must be >= -1")
+
+    import com.rallyhealth.weepickle.v1.laws.LawsVisitor.ObjArrState._
+
+    onValueStart()
+
+    var objState: ObjArrState.State = Initialized
+
+    val underlying = super.visitObject(length)
+    new ObjDelegate[T, J](underlying) {
+      private var keys = 0
+      private var subvisitors = 0
+      private var values = 0
+
+      override def visitKey(): Visitor[_, _] = {
+        keys += 1
+        objState.assertOneOf(Initialized, VisitValue)
+        objState = VisitKeyStart
+        new LawsVisitor[Nothing, Any](super.visitKey()) {
+
+          override protected[LawsVisitor] def onValueStart(
+          )(
+            implicit
+            enc: sourcecode.Enclosing
+          ): Unit = {
+            objState.assertOneOf(VisitKeyStart)
+            super.onValueStart()
+          }
+
+          override protected[LawsVisitor] def onValueEnd(
+          )(
+            implicit
+            enc: sourcecode.Enclosing
+          ): Unit = {
+            super.onValueEnd()
+            objState = VisitKeyComplete
+          }
+        }
+      }
+
+      override def visitKeyValue(
+        s: Any
+      ): Unit = {
+        objState.assertOneOf(VisitKeyComplete)
+        super.visitKeyValue(s)
+        objState = VisitKeyValue
+      }
+
+      override def subVisitor: Visitor[Nothing, Any] = {
+        subvisitors += 1
+        objState.assertOneOf(VisitKeyValue)
+        objState = SubvisitorStart
+        new LawsVisitor[Nothing, Any](super.subVisitor) {
+
+          override protected[LawsVisitor] def onValueStart(
+          )(
+            implicit
+            enc: sourcecode.Enclosing
+          ): Unit = {
+            objState.assertOneOf(SubvisitorStart)
+            super.onValueStart()
+          }
+
+          override protected[LawsVisitor] def onValueEnd(
+          )(
+            implicit
+            enc: sourcecode.Enclosing
+          ): Unit = {
+            super.onValueEnd()
+            objState = SubvisitorComplete
+          }
+        }
+      }
+
+      override def visitValue(
+        v: T
+      ): Unit = {
+        values += 1
+        objState.assertOneOf(SubvisitorComplete)
+        super.visitValue(v)
+        objState = VisitValue
+      }
+
+      override def visitEnd(): J = {
+        objState.assertOneOf(Initialized, VisitValue)
+        objState = VisitEnd
+        onValueEnd()
+        if (keys != subvisitors || keys != values)
+          throw new IllegalStateException(
+            s"Mismatch: visitKey() $keys times, subVisitor() $subvisitors times, visitValue() $values times"
+          )
+        if (length != -1 && keys != length)
+          throw new IllegalStateException(
+            s"visitObject($length), but got $values entries"
+          )
+        super.visitEnd()
+      }
+    }
+  }
+
+  override def visitArray(
+    length: Int
+  ): ArrVisitor[T, J] = {
+    require(length >= -1, s"length $length must be >= -1")
+
+    import ObjArrState._
+
+    onValueStart()
+
+    var arrState: ObjArrState.State = Initialized
+
+    val underlying = super.visitArray(length)
+    new ArrDelegate[T, J](underlying) {
+      private var subvisitors = 0
+      private var values = 0
+
+      override def subVisitor: Visitor[Nothing, Any] = {
+        arrState.assertOneOf(Initialized, VisitValue)
+        arrState = SubvisitorStart
+        subvisitors += 1
+        new LawsVisitor[Nothing, Any](super.subVisitor) {
+
+          override protected[LawsVisitor] def onValueStart(
+          )(
+            implicit
+            enc: sourcecode.Enclosing
+          ): Unit = {
+            arrState.assertOneOf(SubvisitorStart)
+            super.onValueStart()
+          }
+
+          override protected[LawsVisitor] def onValueEnd(
+          )(
+            implicit
+            enc: sourcecode.Enclosing
+          ): Unit = {
+            super.onValueEnd()
+            arrState = SubvisitorComplete
+          }
+        }
+      }
+
+      override def visitValue(
+        v: T
+      ): Unit = {
+        arrState.assertOneOf(SubvisitorComplete)
+        values += 1
+        super.visitValue(v)
+        arrState = VisitValue
+      }
+
+      override def visitEnd(): J = {
+        arrState.assertOneOf(Initialized, VisitValue)
+        onValueEnd()
+        arrState = VisitEnd
+        if (subvisitors != values)
+          throw new IllegalStateException(
+            s"visitEnd() called after $subvisitors subVisitor() and $values visitValue()"
+          )
+        if (length != -1 && subvisitors != length)
+          throw new IllegalStateException(
+            s"visitArray($length), but got $values entries"
+          )
+        super.visitEnd()
+      }
+    }
+  }
+
+  override def visitNull(): J = {
+    onValue()
+    super.visitNull()
+  }
+
+  override def visitTrue(): J = {
+    onValue()
+    super.visitTrue()
+  }
+
+  override def visitFalse(): J = {
+    onValue()
+    super.visitFalse()
+  }
+
+  override def visitString(
+    cs: CharSequence
+  ): J = {
+    onValue()
+    super.visitString(cs)
+  }
+
+  override def visitFloat64StringParts(
+    cs: CharSequence,
+    decIndex: Int,
+    expIndex: Int
+  ): J = {
+    onValue()
+    super.visitFloat64StringParts(cs, decIndex, expIndex)
+  }
+
+  override def visitFloat64(
+    d: Double
+  ): J = {
+    onValue()
+    super.visitFloat64(d)
+  }
+
+  override def visitFloat32(
+    d: Float
+  ): J = {
+    onValue()
+    super.visitFloat32(d)
+  }
+
+  override def visitInt32(
+    i: Int
+  ): J = {
+    onValue()
+    super.visitInt32(i)
+  }
+
+  override def visitInt64(
+    l: Long
+  ): J = {
+    onValue()
+    super.visitInt64(l)
+  }
+
+  override def visitUInt64(
+    ul: Long
+  ): J = {
+    onValue()
+    super.visitUInt64(ul)
+  }
+
+  override def visitFloat64String(
+    s: String
+  ): J = {
+    onValue()
+    super.visitFloat64String(s)
+  }
+
+  override def visitChar(
+    c: Char
+  ): J = {
+    onValue()
+    super.visitChar(c)
+  }
+
+  override def visitBinary(
+    bytes: Array[Byte],
+    offset: Int,
+    len: Int
+  ): J = {
+    onValue()
+    super.visitBinary(bytes, offset, len)
+  }
+
+  override def visitExt(
+    tag: Byte,
+    bytes: Array[Byte],
+    offset: Int,
+    len: Int
+  ): J = {
+    onValue()
+    super.visitExt(tag, bytes, offset, len)
+  }
+
+  override def visitTimestamp(
+    instant: Instant
+  ): J = {
+    onValue()
+    super.visitTimestamp(instant)
+  }
+}
+
+object LawsVisitor {
+
+  trait StateEnumeration extends Enumeration {
+
+    final class State extends super.Val {
+
+      def assertOneOf(
+        validStates: State*
+      )(
+        implicit
+        enc: sourcecode.Enclosing
+      ) = {
+        if (!validStates.contains(this)) {
+          throw new IllegalStateException(
+            validStates.mkString(
+              s"Invalid call to ${enc.value}. currentState=$this validStates=[",
+              ", ",
+              "]"
+            )
+          )
+        }
+      }
+    }
+  }
+
+  object ObjArrState extends StateEnumeration {
+
+    val Initialized, VisitKeyStart, VisitKeyComplete, VisitKeyValue,
+    SubvisitorStart, SubvisitorComplete, VisitValue, VisitEnd = new State()
+  }
+
+  object VisitorState extends StateEnumeration {
+
+    val Initialized, VisitStart, VisitComplete, Closed = new State()
+  }
+}
+

--- a/weepickle-laws/src/test/scala/com/rallyhealth/weepickle/v1/laws/LawsVisitorTests.scala
+++ b/weepickle-laws/src/test/scala/com/rallyhealth/weepickle/v1/laws/LawsVisitorTests.scala
@@ -1,0 +1,187 @@
+package com.rallyhealth.weepickle.v1.laws
+
+import com.rallyhealth.weejson.v1.{GenValue, Value}
+import com.rallyhealth.weepickle.v1.core.NullVisitor
+import org.scalacheck.Prop.forAll
+import utest._
+
+import java.time.Instant
+
+object LawsVisitorTests
+  extends utest.TestSuite
+  with UTestScalaCheck
+  with GenValue {
+
+  type E = IllegalStateException
+
+  override val tests: Tests = Tests {
+
+    "positive" - {
+      "Value" - check {
+        forAll { (v: Value) =>
+          v.transform(new LawsVisitor(Value)) ==> v
+        }
+      }
+    }
+
+    "negative" - {
+      val parent = new LawsVisitor(NullVisitor)
+
+      "close no value" - intercept[E](parent.close())
+
+      "close" - {
+        parent.visitTrue()
+        parent.close()
+
+        "close" - intercept[E](parent.close())
+        "visitObj" - intercept[E](parent.visitObject(-1))
+        "visitArr" - intercept[E](parent.visitArray(-1))
+        "visitNull" - intercept[E](parent.visitNull())
+        "visitTrue" - intercept[E](parent.visitTrue())
+        "visitFalse" - intercept[E](parent.visitFalse())
+        "visitString" - intercept[E](parent.visitString(""))
+        "visitFloat64StringParts" - intercept[E](
+          parent.visitFloat64StringParts("", 1, 1)
+        )
+        "visitFloat64" - intercept[E](parent.visitFloat64(1.1))
+        "visitFloat32" - intercept[E](parent.visitFloat32(1.1f))
+        "visitInt32" - intercept[E](parent.visitInt32(1))
+        "visitInt64" - intercept[E](parent.visitInt64(1))
+        "visitUInt64" - intercept[E](parent.visitUInt64(1))
+        "visitFloat64String" - intercept[E](parent.visitFloat64String(""))
+        "visitChar" - intercept[E](parent.visitChar('c'))
+        "visitBinary" - intercept[E](
+          parent.visitBinary("pony".getBytes(), 0, 4)
+        )
+        "visitExt" - intercept[E](
+          parent.visitExt(0, Array.emptyByteArray, 0, 0)
+        )
+        "visitTimestamp" - intercept[E](parent.visitTimestamp(Instant.now()))
+      }
+
+      "visitObj" - {
+        val obj = parent.visitObject(-1).narrow
+
+        "parent" - {
+          "visitTrue" - intercept[E](parent.visitTrue())
+          "visitObj" - intercept[E](parent.visitObject(-1))
+          "visitArr" - intercept[E](parent.visitArray(-1))
+          "close" - intercept[E](parent.close())
+        }
+
+        "visitKeyValue" - intercept[E](obj.visitKeyValue(""))
+        "subVisitor" - intercept[E](obj.subVisitor)
+        "visitValue" - intercept[E](obj.visitValue(""))
+
+        "visitKey" - {
+          val kv = obj.visitKey()
+
+          "twice" - intercept[E](obj.visitKey())
+          "visitKeyValue" - intercept[E](obj.visitKeyValue(""))
+          "kv.visitFalse" - {
+            kv.visitFalse()
+
+            "twice" - intercept[E](kv.visitFalse())
+            "subVisitor" - intercept[E](obj.subVisitor)
+            "visitValue" - intercept[E](obj.visitValue(""))
+            "visitKeyValue" - {
+              obj.visitKeyValue(false)
+
+              "visitKey" - intercept[E](obj.visitKey())
+              "visitKeyValue" - intercept[E](obj.visitKeyValue(""))
+              "visitValue" - intercept[E](obj.visitValue(""))
+              "visitEnd" - intercept[E](obj.visitEnd())
+              "subVisitor" - {
+                val sub = obj.subVisitor
+
+                "visitKey" - intercept[E](obj.visitKey())
+                "visitKeyValue" - intercept[E](obj.visitKeyValue(""))
+                "subVisitor" - intercept[E](obj.subVisitor)
+                "visitValue" - intercept[E](obj.visitValue(""))
+                "visitEnd" - intercept[E](obj.visitEnd())
+                "visitTrue" - {
+                  sub.visitTrue()
+
+                  "visitKey" - intercept[E](obj.visitKey())
+                  "visitKeyValue" - intercept[E](obj.visitKeyValue(""))
+                  "subVisitor" - intercept[E](obj.subVisitor)
+                  "visitEnd" - intercept[E](obj.visitEnd())
+                  "visitValue" - {
+                    obj.visitValue(true)
+
+                    "visitKeyValue" - intercept[E](obj.visitKeyValue(""))
+                    "subVisitor" - intercept[E](obj.subVisitor)
+                    "parent" - intercept[E](parent.visitTrue())
+                    "visitEnd" - {
+                      obj.visitEnd()
+
+                      "visitEnd" - intercept[E](obj.visitEnd())
+                      "visitKey" - intercept[E](obj.visitKey())
+                      "visitKeyValue" - intercept[E](obj.visitKeyValue(""))
+                      "subVisitor" - intercept[E](obj.subVisitor)
+                      "visitValue" - intercept[E](obj.visitValue(""))
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      "visitArr" - {
+        val arr = parent.visitArray(-1).narrow
+
+        "parent" - {
+          "visitTrue" - intercept[E](parent.visitTrue())
+          "visitObj" - intercept[E](parent.visitObject(-1))
+          "visitArr" - intercept[E](parent.visitArray(-1))
+          "close" - intercept[E](parent.close())
+        }
+
+        "subVisitor" - {
+          val sub1 = arr.subVisitor
+
+          "subVisitor" - intercept[E](arr.subVisitor)
+          "visitValue" - intercept[E](arr.visitValue(""))
+          "visitInt" - {
+            sub1.visitInt32(42)
+
+            "subVisitor" - intercept[E](arr.subVisitor)
+            "visitEnd" - intercept[E](arr.visitEnd())
+            "visitValue" - {
+              arr.visitValue(42)
+
+              "parent" - intercept[E](parent.visitTrue())
+              "visitEnd" - {
+                arr.visitEnd()
+              }
+
+              "subVisitor" - {
+                val sub2 = arr.subVisitor
+
+                "sub1" - intercept[E](sub1.visitTrue())
+                "subVisitor" - intercept[E](arr.subVisitor)
+                "visitValue" - intercept[E](arr.visitValue(""))
+                "visitInt" - {
+                  sub2.visitInt32(42)
+
+                  "subVisitor" - intercept[E](arr.subVisitor)
+                  "visitEnd" - intercept[E](arr.visitEnd())
+                  "visitValue" - {
+                    arr.visitValue(42)
+
+                    "parent" - intercept[E](parent.visitTrue())
+                    "visitEnd" - {
+                      arr.visitEnd()
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/weepickle-laws/src/test/scala/com/rallyhealth/weepickle/v1/laws/UTestScalaCheck.scala
+++ b/weepickle-laws/src/test/scala/com/rallyhealth/weepickle/v1/laws/UTestScalaCheck.scala
@@ -1,0 +1,42 @@
+package com.rallyhealth.weepickle.v1.laws
+
+import org.scalacheck.Test.PropException
+import org.scalacheck.util.Pretty
+import org.scalacheck.{Prop, Test}
+
+import scala.language.implicitConversions
+import scala.util.control.NoStackTrace
+
+/**
+  * Adapted from https://github.com/lihaoyi/utest/issues/2#issuecomment-67300735
+  */
+trait UTestScalaCheck {
+
+  protected[this] object UTestReporter extends Test.TestCallback {
+
+    private val prettyParams = Pretty.defaultParams
+
+    override def onTestResult(
+      name: String,
+      res: org.scalacheck.Test.Result
+    ) = {
+      if (!res.passed) {
+        val msg =
+          s"ScalaCheck property failed:\n${Pretty.pretty(res, prettyParams)}"
+        val cause = Some(res.status).collect {
+          case PropException(_, t, _) => t
+        }.orNull
+        throw new AssertionError(msg, cause) with NoStackTrace
+      }
+    }
+  }
+
+  /**
+    * We're going to throw rather than returning a status.
+    */
+  protected implicit def propUnit(u: Unit): Prop = Prop(true)
+
+  def check(
+    prop: Prop
+  ): Unit = prop.check(Test.Parameters.default.withTestCallback(UTestReporter))
+}

--- a/weepickle/src/main/scala/com/rallyhealth/weepickle/v1/WeePickle.scala
+++ b/weepickle/src/main/scala/com/rallyhealth/weepickle/v1/WeePickle.scala
@@ -1,12 +1,15 @@
 package com.rallyhealth.weepickle.v1
 
+import com.rallyhealth.weepickle.v1.core.ops.FromInputOpsImplicits
 import com.rallyhealth.weepickle.v1.core.{FromInput, Visitor}
 
 /**
   * Converters for default scala types.
   * Macros to generate converters for case classes.
   */
-object WeePickle extends LowPriorityImplicits {
+object WeePickle
+  extends LowPriorityImplicits
+  with FromInputOpsImplicits {
 
   object ToScala {
 

--- a/weepickle/src/test/scala/com/rallyhealth/weepickle/v1/ConcatFromInputsSpec.scala
+++ b/weepickle/src/test/scala/com/rallyhealth/weepickle/v1/ConcatFromInputsSpec.scala
@@ -1,0 +1,61 @@
+package com.rallyhealth.weepickle.v1
+
+import com.rallyhealth.weejson.v1.jackson.ToJson
+import com.rallyhealth.weejson.v1.{Arr, Obj, Value}
+import com.rallyhealth.weepickle.v1.laws.LawsVisitor
+import com.rallyhealth.weepickle.v1.WeePickle.FromScala
+import com.rallyhealth.weepickle.v1.core.Abort
+import com.rallyhealth.weepickle.v1.core.ops.FromInputOpsImplicits
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class ConcatFromInputsSpec
+  extends AnyFreeSpec
+  with Matchers
+  with TypeCheckedTripleEquals
+  with FromInputOpsImplicits {
+
+  "obj" - {
+    "empty" in (concat(Obj()) shouldBe """{}""")
+    "a" in (concat(Obj("a" -> 1)) shouldBe """{"a":1}""")
+    "ab" in (concat(Obj("a" -> 1), Obj("b" -> 2)) shouldBe """{"a":1,"b":2}""")
+    "aa" in (concat(Obj("a" -> 1), Obj("a" -> 2)) shouldBe """{"a":1,"a":2}""")
+    "abc" in (concat(Obj("a" -> 1), Obj("b" -> 2), Obj("c" -> 3)) shouldBe """{"a":1,"b":2,"c":3}""")
+    "no StackOverflowError" in {
+      val obj = Obj("a" -> 1)
+      (noException should be thrownBy (concat(
+        IndexedSeq.fill(1000 * 1000)(obj)
+      )))
+    }
+  }
+
+  "arr" - {
+    "a" in (concat(Arr(1)) shouldBe """[1]""")
+    "ab" in (concat(Arr(1), Arr(2)) shouldBe """[1,2]""")
+    "abc" in (concat(Arr(1, 2, 3)) shouldBe """[1,2,3]""")
+    "no StackOverflowError" in {
+      val arr = Arr(1)
+      (noException should be thrownBy (concat(
+        IndexedSeq.fill(1000 * 1000)(arr)
+      )))
+    }
+  }
+
+  "invalid" - {
+    "arr obj" in (a[Abort] shouldBe thrownBy(
+      concat(Arr(1), Obj())
+    ))
+    "arr int" in (a[Abort] shouldBe thrownBy(concat(Arr(1), 2)))
+    "obj int" in (a[Abort] shouldBe thrownBy(concat(Obj("a" -> 1), 2)))
+  }
+
+  private def concat(
+    objs: Value*
+  ): String = {
+    objs
+      .map(FromScala(_))
+      .reduce(_ ++ _)
+      .transform(new LawsVisitor(ToJson.string))
+  }
+}


### PR DESCRIPTION
This is a first step toward open sourcing some of our higher-level weePickle code, starting with `ConcatFromInputs`. The big decision is where it should live. We could carve out another jar, but I think it makes the sense to add most of the `visitation` stuff directly to `weepickle-core`.