### PR TITLE
Add JsValueSingletons.jsObjectEmpty

### DIFF
--- a/weejson-play/src/main/scala/com/rallyhealth/weejson/v1/play/JsValueSingletons.scala
+++ b/weejson-play/src/main/scala/com/rallyhealth/weejson/v1/play/JsValueSingletons.scala
@@ -1,0 +1,13 @@
+package com.rallyhealth.weejson.v1.play
+
+import play.api.libs.json.{JsBoolean, JsObject}
+
+/**
+  * Shared values to reduce memory usage.
+  */
+object JsValueSingletons {
+
+  val jsTrue = JsBoolean(true)
+  val jsFalse = JsBoolean(false)
+  val jsObjectEmpty = JsObject.empty
+}

--- a/weejson-play/src/main/scala/com/rallyhealth/weejson/v1/play/JsValueSingletons.scala
+++ b/weejson-play/src/main/scala/com/rallyhealth/weejson/v1/play/JsValueSingletons.scala
@@ -7,7 +7,7 @@ import play.api.libs.json.{JsBoolean, JsObject}
   */
 object JsValueSingletons {
 
-  val jsTrue = JsBoolean(true)
-  val jsFalse = JsBoolean(false)
-  val jsObjectEmpty = JsObject.empty
+  final val jsTrue = JsBoolean(true)
+  final val jsFalse = JsBoolean(false)
+  final val jsObjectEmpty = JsObject(List.empty)
 }

--- a/weejson-play/src/main/scala/com/rallyhealth/weejson/v1/play/PlayJson.scala
+++ b/weejson-play/src/main/scala/com/rallyhealth/weejson/v1/play/PlayJson.scala
@@ -10,13 +10,9 @@ import scala.jdk.CollectionConverters._
 
 object PlayJson extends PlayJson {
 
-  // common singletons to avoid heap bloat
-  private[this] val jsTrue = JsBoolean(true)
-  private[this] val jsFalse = JsBoolean(false)
+  override def visitTrue(): JsValue = JsValueSingletons.jsTrue
 
-  override def visitTrue(): JsValue = jsTrue
-
-  override def visitFalse(): JsValue = jsFalse
+  override def visitFalse(): JsValue = JsValueSingletons.jsFalse
 }
 
 class PlayJson extends com.rallyhealth.weejson.v1.AstTransformer[JsValue] {
@@ -45,7 +41,10 @@ class PlayJson extends com.rallyhealth.weejson.v1.AstTransformer[JsValue] {
 
       override def visitValue(v: JsValue): Unit = vs.put(key, v)
 
-      override def visitEnd(): JsValue = JsObject(vs)
+      override def visitEnd(): JsValue = {
+        if (vs.isEmpty) JsValueSingletons.jsObjectEmpty
+        else JsObject(vs)
+      }
     }
 
   def visitNull(): JsValue = JsNull


### PR DESCRIPTION
Across our test dataset, 18% of all `JsObject`s are empty. 

![# objects by field size in test data set](https://user-images.githubusercontent.com/663139/144541706-eb2c3899-0583-4698-b886-ee17a41c318c.png)

Heap sizes (🔴 and 🟢 are the PR changes):
![Heap usage relative to UnorderedPlayJson (1)](https://user-images.githubusercontent.com/663139/144544270-4eddc200-3b78-488b-bf4c-b61673ffd751.png)

Savings range from 0-15% with an average of~1%. `UnorderedPlayJson` benefits less since it already shares `EmptyMap`. Labcorp.json shaves off 248 MB out of 3,355 MB. It also cuts the DoS potential from the horrible 63x memory amplification string, `[{},{},{},...]`. Latter two examples aren't pictured in the graph.
