### PR TITLE
PlayJson memory and throughput improvements

### DIFF
--- a/bench/src/main/scala/com/rallyhealth/weejson/v1/play/JsObjectBench.scala
+++ b/bench/src/main/scala/com/rallyhealth/weejson/v1/play/JsObjectBench.scala
@@ -1,0 +1,106 @@
+package com.rallyhealth.weejson.v1.play
+
+import com.rallyhealth.weepickle.v1.core.Visitor
+import org.openjdk.jmh.annotations._
+import play.api.libs.json.{JsArray, JsObject, JsValue}
+
+import java.util.concurrent.TimeUnit
+
+/**
+  * Simulates `.transform(PlayJson).as[T]` for various object sizes.
+  *
+  * ==Quick Run==
+  * bench / Jmh / run -f1 -wi 2 -i 3 -p visitor=PlayJson,UnorderedPlayJson -p size=0,1,4,256 .*JsValueBench
+  *
+  * ==Profile with Flight Recorder==
+  * bench / Jmh / run -prof jfr -f1 .*JsValueBench
+  *
+  * ==Jmh Visualizer Report==
+  * bench / Jmh / run -prof gc -rf json -rff JsValueBench-results.json .*JsValueBench
+  *
+  * {{{
+  * Benchmark            (size)          (visitor)   Mode  Cnt       Score      Error   Units
+  * JsValueBench.jsArray      0           PlayJson  thrpt    6  148997.034 ± 3110.524  ops/ms
+  * JsValueBench.jsArray      0  UnorderedPlayJson  thrpt    6  148811.991 ± 2403.647  ops/ms
+  * JsValueBench.jsArray      1           PlayJson  thrpt    6   14538.941 ±  958.018  ops/ms
+  * JsValueBench.jsArray      1  UnorderedPlayJson  thrpt    6   14872.016 ±  200.060  ops/ms
+  * JsValueBench.jsArray     10           PlayJson  thrpt    6    6454.029 ±  111.689  ops/ms
+  * JsValueBench.jsArray     10  UnorderedPlayJson  thrpt    6    6459.146 ±  181.786  ops/ms
+  * JsValueBench.jsObject     0           PlayJson  thrpt    6  152411.656 ± 2513.943  ops/ms
+  * JsValueBench.jsObject     0  UnorderedPlayJson  thrpt    6  151380.994 ± 3999.946  ops/ms
+  * JsValueBench.jsObject     1           PlayJson  thrpt    6    8474.548 ±  149.389  ops/ms
+  * JsValueBench.jsObject     1  UnorderedPlayJson  thrpt    6    8510.589 ±  245.733  ops/ms
+  * JsValueBench.jsObject    10           PlayJson  thrpt    6    1987.599 ±   32.466  ops/ms
+  * JsValueBench.jsObject    10  UnorderedPlayJson  thrpt    6    1560.828 ±   30.813  ops/ms
+  * }}}
+  * @see https://github.com/ktoso/sbt-jmh
+  */
+@Warmup(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(jvmArgsAppend = Array("-Xmx350m", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:-BackgroundCompilation", "-XX:-TieredCompilation"), value = 1)
+class JsValueBench {
+
+  @Param(Array("PlayJson", "UnorderedPlayJson"))
+  var visitor: String = _
+  var v: Visitor[JsValue, JsValue] = _
+
+  @Param(Array("0", "1", "4", "8", "32", "64", "256", "1024"))
+  var size: Int = _
+  var strings: Array[String] = _
+
+  @Setup def setup: Unit = {
+    v = visitor match {
+      case "PlayJson" => PlayJson
+      case "UnorderedPlayJson" => UnorderedPlayJson
+      case o => throw new IllegalArgumentException(o)
+    }
+    strings = (0 until size).map(_.toString).toArray // cached String.hashcode
+  }
+
+  @Benchmark def jsObject: JsValue = {
+    var i = 0
+    val o = v.visitObject(-1).narrow
+    while (i < size) {
+      o.visitKeyValue(o.visitKey().visitString(strings(i)))
+      o.visitValue(o.subVisitor.visitNull())
+      i += 1
+    }
+    val jsValue = o.visitEnd()
+    simulateCaseClassMapping(jsValue)
+    jsValue
+  }
+
+  @Benchmark def jsArray: JsValue = {
+    var i = 0
+    val o = v.visitArray(-1).narrow
+    while (i < size) {
+      o.visitValue(o.subVisitor.visitNull())
+      i += 1
+    }
+    val jsValue = o.visitEnd()
+    simulateCaseClassMapping(jsValue)
+    jsValue
+  }
+
+  private def simulateCaseClassMapping(
+    jsValue: JsValue
+  ): Unit = {
+    jsValue match {
+      case JsObject(underlying) =>
+        underlying.keysIterator.foreach { key =>
+          // Reads macro uses underlying.get(key), not (obj \ "key")!
+          // https://github.com/playframework/play-json/pull/674
+          underlying.get(key) match {
+            case Some(jsValue) => simulateCaseClassMapping(jsValue)
+            case _ =>
+          }
+        }
+      case JsArray(value) =>
+        value.foreach(simulateCaseClassMapping)
+      case _ => ()
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ lazy val bench = project
   .dependsOn(
     `weepickle-tests` % "compile;test",
     `weejson-upickle`,
+    `weejson-play29`,
   )
   .enablePlugins(JmhPlugin)
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ lazy val bench = project
   .enablePlugins(JmhPlugin)
   .settings(
     noPublish,
-    crossScalaVersions := Seq(scala213, scala3),
+    crossScalaVersions := Seq(scala213),
     libraryDependencies ++= Seq(
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.0",
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-smile" % "2.13.0",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.9.2")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.2")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")

--- a/weejson-play/src/main/scala/com/rallyhealth/weejson/v1/play/JsValueSingletons.scala
+++ b/weejson-play/src/main/scala/com/rallyhealth/weejson/v1/play/JsValueSingletons.scala
@@ -1,6 +1,6 @@
 package com.rallyhealth.weejson.v1.play
 
-import play.api.libs.json.{JsBoolean, JsObject}
+import play.api.libs.json.{JsArray, JsBoolean, JsObject}
 
 /**
   * Shared values to reduce memory usage.
@@ -9,5 +9,6 @@ object JsValueSingletons {
 
   final val jsTrue = JsBoolean(true)
   final val jsFalse = JsBoolean(false)
-  final val jsObjectEmpty = JsObject(List.empty)
+  object EmptyJsObject extends JsObject(Map.empty)
+  object EmptyJsArray extends JsArray()
 }

--- a/weejson-play/src/main/scala/com/rallyhealth/weejson/v1/play/PlayJson.scala
+++ b/weejson-play/src/main/scala/com/rallyhealth/weejson/v1/play/PlayJson.scala
@@ -7,6 +7,7 @@ import com.rallyhealth.weepickle.v1.core.{ArrVisitor, ObjVisitor, StringVisitor,
 import play.api.libs.json._
 
 import java.util.{LinkedHashMap => JLinkedHashMap}
+import scala.collection.compat.immutable.ArraySeq
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 
@@ -30,7 +31,7 @@ class PlayJson extends AstTransformer[JsValue] {
   def visitArray(length: Int): ArrVisitor[JsValue, JsValue] = {
     new ArrVisitor[JsValue, JsValue] {
       // initCapacity=4 covers 90% of real-world objs. Faster overall. (JsValueBench)
-      private[this] val buf = new ArrayBuffer[JsValue](if (length >= 0) length else 4)
+      private[this] val buf = new ArrayBuffer[AnyRef](if (length >= 0) length else 4)
 
       override def subVisitor: Visitor[_, _] = PlayJson.this
 
@@ -38,7 +39,7 @@ class PlayJson extends AstTransformer[JsValue] {
 
       override def visitEnd(): JsValue = {
         if (buf.isEmpty) JsValueSingletons.EmptyJsArray
-        else JsArray(buf.toArray[JsValue])
+        else JsArray(ArraySeq.unsafeWrapArray(buf.toArray).asInstanceOf[ArraySeq[JsValue]])
       }
     }
   }

--- a/weejson-play/src/main/scala/com/rallyhealth/weejson/v1/play/UnorderedPlayJson.scala
+++ b/weejson-play/src/main/scala/com/rallyhealth/weejson/v1/play/UnorderedPlayJson.scala
@@ -1,6 +1,6 @@
 package com.rallyhealth.weejson.v1.play
 
-import com.rallyhealth.weepickle.v1.core.ObjVisitor
+import com.rallyhealth.weepickle.v1.core.{ObjVisitor, StringVisitor, Visitor}
 import play.api.libs.json._
 
 import scala.collection.immutable.TreeMap
@@ -10,7 +10,12 @@ object UnorderedPlayJson extends UnorderedPlayJson
 
 /**
   * Uses ~0.6x of the heap of [[PlayJson]] in exchange for undefined order of JsObject keys.
-  * Ideal for {{{jsValue.as[T]}}} where order is irrelevant.
+  * Ideal for {{{jsValue.as[T]}}} where order is irrelevant and inputs may be large.
+  *
+  * Throughput of {{{ .transform(UnorderedPlayJson).as[T] }}} is typically
+  * only 0.8x of [[PlayJson]] when memory is plentiful. Becomes faster than
+  * [[PlayJson]] when the memory savings would prevent GC pressure, e.g. large
+  * messages, high parallelism, or both.
   *
   * Heap usage for a particularly large JSON file captured from the wild:
   *  - 814 MB:   `Array[Byte]`
@@ -21,13 +26,23 @@ object UnorderedPlayJson extends UnorderedPlayJson
   */
 class UnorderedPlayJson extends PlayJson {
 
-  override def visitObject(length: Int): ObjVisitor[JsValue, JsValue] = {
-    new AstObjVisitor[ArrayBuffer[(String, JsValue)]](toJsObject)
-  }
+  override def visitObject(length: Int): ObjVisitor[JsValue, JsValue] = new ObjVisitor[JsValue, JsValue] {
+    private[this] var key: String = _
+    // initCapacity=4 covers 88% of real-world objs. Faster overall. (JsValueBench)
+    private[this] val buf = new ArrayBuffer[(String, JsValue)](if (length >= 0) length else 4)
 
-  private def toJsObject(buf: ArrayBuffer[(String, JsValue)]) = {
-    if (buf.isEmpty) JsValueSingletons.jsObjectEmpty
-    else if (buf.size <= 4) JsObject(buf.toMap)
-    else JsObject((TreeMap.newBuilder[String, JsValue] ++= buf).result())
+    override def visitKey(): Visitor[_, _] = StringVisitor
+
+    override def visitKeyValue(v: Any): Unit = key = v.toString
+
+    override def subVisitor: Visitor[_, _] = UnorderedPlayJson.this
+
+    override def visitValue(v: JsValue): Unit = buf += (key -> v)
+
+    override def visitEnd(): JsValue = {
+      if (buf.isEmpty) JsValueSingletons.EmptyJsObject
+      else if (buf.size <= 4) JsObject(buf.toMap) // preserves order
+      else JsObject((TreeMap.newBuilder[String, JsValue] ++= buf).result())
+    }
   }
 }


### PR DESCRIPTION
Memory savings:
- `object EmptyJsArray extends JsArray()`. It's only 12% of the arrays in my test data, and `[]` requires much less heap than `{}`, but hey, it's savings.
- `JsObject` uses `Map1-4` now when possible. I previously thought we couldn't use it since `Map1-4` lose order on `++`, but that happens even with play-json's default `j.u.LinkedHashMap` under `JsObject`:
    ```scala
    Json.obj("2" -> JsTrue, "1" -> JsTrue)               // {"2":true,"1":true}
    Json.obj("2" -> JsTrue, "1" -> JsTrue) ++ Json.obj() // {"1":true,"2":true}
    ```

Throughput:
- `AstArrVisitor` and `AstObjVisitor` are convenient and terse, but they hurt throughput, especially over the size=0 case. I haven't fully looked into why. Removing them for now.