### PR TITLE
Fix JSON => BigDecimal precision loss. Optimize FromJson

### DIFF
--- a/weejson-jackson/src/main/scala/com/rallyhealth/weejson/v1/jackson/DefaultJsonFactory.scala
+++ b/weejson-jackson/src/main/scala/com/rallyhealth/weejson/v1/jackson/DefaultJsonFactory.scala
@@ -1,8 +1,11 @@
 package com.rallyhealth.weejson.v1.jackson
 
-import com.fasterxml.jackson.core.JsonFactory
+import com.fasterxml.jackson.core.{JsonFactory, JsonFactoryBuilder}
 
 object DefaultJsonFactory {
 
-  final val Instance = new JsonFactory() // javadoc suggests reusing this
+  final val Instance: JsonFactory = // javadoc suggests reusing this
+    new JsonFactoryBuilder()
+      .configure(JsonFactory.Feature.INTERN_FIELD_NAMES, false) // vuln to String.hashcode collisions
+      .build()
 }

--- a/weejson-jackson/src/main/scala/com/rallyhealth/weejson/v1/jackson/FromJson.scala
+++ b/weejson-jackson/src/main/scala/com/rallyhealth/weejson/v1/jackson/FromJson.scala
@@ -1,12 +1,14 @@
 package com.rallyhealth.weejson.v1.jackson
 
-import java.io.{File, InputStream, Reader}
-import java.nio.file.Path
-
-import com.fasterxml.jackson.core.io.JsonEOFException
-import com.fasterxml.jackson.core.{JsonFactory, JsonParseException, JsonParser}
+import com.fasterxml.jackson.core.JsonParser.NumberType
+import com.fasterxml.jackson.core.JsonToken._
+import com.fasterxml.jackson.core.JsonTokenId._
+import com.fasterxml.jackson.core.{JsonFactory, JsonParser, JsonToken, JsonTokenId}
 import com.rallyhealth.weepickle.v1.core.{CallbackVisitor, FromInput, TransformException, Visitor}
 
+import java.io.{File, InputStream, Reader}
+import java.nio.file.Path
+import scala.annotation.switch
 import scala.util.Try
 import scala.util.control.NonFatal
 
@@ -49,20 +51,12 @@ abstract class JsonParserOps(factory: JsonFactory = DefaultJsonFactory.Instance)
   */
 class JsonFromInput(parser: JsonParser) extends FromInput {
 
-  override def transform[T](to: Visitor[_, T]): T = {
-    if (parser.nextToken() == null) {
-      // There are no tokens at all
-      throw new JsonEOFException(parser, null, "There were no tokens to parse")
-    }
-
-    val builder = List.newBuilder[T]
-    val generator = new VisitorJsonGenerator(
-      new CallbackVisitor(to)(builder += _)
-    )
-
+  override def transform[J](
+    to: Visitor[_, J]
+  ): J = {
     try {
-      generator.copyCurrentStructure(parser)
-
+      parser.nextToken()
+      val result = parseRec(to, 64)(parser)
       if (parser.nextToken() != null) {
         // Multiple values is unsupported at this level of abstraction.
         // https://tools.ietf.org/html/rfc8259#section-2 says:
@@ -70,19 +64,148 @@ class JsonFromInput(parser: JsonParser) extends FromInput {
         // If you want multiple whitespace separated values, you'll have to use lower level APIs.
         throw JsonParserException("Unexpected data after end of single json value", parser)
       }
-
-      builder.result() match {
-        case Nil         => throw JsonParserException("Reached end of input, but Visitor produced no result.", parser)
-        case head :: Nil => head
-        case many        => throw JsonParserException("Expected 1 result. Visitor produced many.", parser)
-      }
+      result
     } catch {
-      case ve: TransformException => throw ve
+      case t: TransformException =>
+        throw t
       case NonFatal(t) =>
         throw JsonParserException("Parser or Visitor failure", parser, t)
     } finally {
       Try(parser.close()) // completely consumed.
-      Try(generator.close()) // we created it, so we close it.
+    }
+  }
+
+  /**
+    * Mimics [[com.fasterxml.jackson.core.JsonGenerator#copyCurrentStructure]],
+    * but does not lose precision over JSON BigDecimal numbers.
+    *
+    * Uses on-stack Obj/ArrVisitor tracking up to some fixed depth, then falls
+    * back to a stack-safe approach.
+    *
+    * Precondition: parser points to the token to be parsed, e.g. STRING, START_ARRAY, etc.
+    * Post-condition: parser points to the last token parsed, e.g. STRING, END_ARRAY, etc.
+    */
+  private def parseRec[T, J](
+    v: Visitor[T, J],
+    remainingDepth: Int
+  )(implicit
+    p: JsonParser
+  ): J = {
+    val token = p.currentToken()
+    if (token == null) throw JsonParserException("Premature EOF", p)
+    (token.id(): @switch) match {
+      case ID_NOT_AVAILABLE | ID_NO_TOKEN =>
+        throw JsonParserException("No current event to copy", p)
+      case ID_EMBEDDED_OBJECT =>
+        copyStackSafe(v)
+      case ID_STRING =>
+        val start = p.getTextOffset
+        val end = start + p.getTextLength
+        val cs = new runtime.ArrayCharSequence(p.getTextCharacters, start, end)
+        v.visitString(cs)
+      case ID_FIELD_NAME =>
+        v.visitString(p.getCurrentName)
+      case ID_NUMBER_INT =>
+        p.getNumberType match {
+          case NumberType.INT => v.visitInt32(p.getIntValue)
+          case NumberType.LONG => v.visitInt64(p.getLongValue)
+          case _ => v.visitFloat64String(p.getValueAsString)
+        }
+      case ID_NUMBER_FLOAT =>
+        // p.getNumberType cannot be trusted!
+        // For JSON, it always returns DOUBLE, even if the number would lose precision.
+        // getNumberValueExact() always returns a BigDecimal (-50% perf)
+        // So we toss the "float" in a string and let the Visitor figure it out.
+        // Being lazy can be a boon. Visitor might not even use the value.
+        // For jackson-dataformats-binary, this results in unfortunate conversions from
+        // base2 => base10 => base2, but there's currently no way to know when
+        // JsonParser.getNumberType() will answer accurately without add'l cost.
+        // Wishlist: `JsonParser.isCurrentNumberTypeGuaranteedExact(): Boolean`
+        v.visitFloat64String(p.getValueAsString())
+      case ID_NULL =>
+        v.visitNull()
+      case ID_TRUE =>
+        v.visitTrue()
+      case ID_FALSE =>
+        v.visitFalse()
+      case ID_START_ARRAY =>
+        val depthM1 = remainingDepth - 1
+        if (depthM1 < 0) copyStackSafe(v)
+        else {
+          if (p.nextToken() == END_ARRAY) {
+            v.visitArray(0).visitEnd()
+          } else {
+            val arr = v.visitArray(-1).narrow
+            while ( {
+              arr.visitValue(parseRec(arr.subVisitor, depthM1))
+              p.nextToken() != END_ARRAY
+            }) ()
+            arr.visitEnd()
+          }
+        }
+      case ID_START_OBJECT =>
+        val depthM1 = remainingDepth - 1
+        if (depthM1 < 0) copyStackSafe(v)
+        else {
+          if (p.nextToken() == END_OBJECT) {
+            v.visitObject(0).visitEnd()
+          } else {
+            val obj = v.visitObject(-1).narrow
+            while ( {
+              obj.visitKeyValue(parseRec(obj.visitKey(), depthM1))
+              p.nextToken()
+              obj.visitValue(parseRec(obj.subVisitor, depthM1))
+              p.nextToken() != JsonToken.END_OBJECT
+            }) ()
+            obj.visitEnd()
+          }
+        }
+      case _ =>
+        throw JsonParserException(s"unknown current token $token", p)
+    }
+  }
+
+  /**
+    * Precondition: parser points to the token to be parsed, e.g. STRING, START_ARRAY, etc.
+    * Post-condition: parser points to the last token parsed, e.g. STRING, END_ARRAY, etc.
+    */
+  private def copyStackSafe[J](
+    visitor: Visitor[_, J]
+  )(implicit
+    parser: JsonParser
+  ): J = {
+    // this stuff is slower, but only used rarely at high depth.
+    val builder = List.newBuilder[J]
+    val generator =
+      new VisitorJsonGenerator(
+        new CallbackVisitor(visitor)(builder += _)
+      )
+
+    var depth = 0
+    while ( {
+      import JsonTokenId._
+      val token = parser.currentToken()
+      token.id match {
+        case ID_NUMBER_FLOAT =>
+          // Special case float: https://github.com/FasterXML/jackson-core/issues/730
+          generator.writeNumber(parser.getValueAsString)
+        case ID_START_OBJECT | ID_START_ARRAY =>
+          depth += 1
+          generator.copyCurrentEvent(parser)
+        case ID_END_OBJECT | ID_END_ARRAY =>
+          depth -= 1
+          generator.copyCurrentEvent(parser)
+        case _ =>
+          generator.copyCurrentEvent(parser)
+      }
+      // advance to next token except for the last one
+      depth > 0 && parser.nextToken() != null
+    }) ()
+
+    builder.result() match {
+      case Nil         => throw JsonParserException("Reached end of input, but Visitor produced no result.", parser)
+      case head :: Nil => head
+      case many        => throw JsonParserException("Expected 1 result. Visitor produced many.", parser)
     }
   }
 }

--- a/weejson-jackson/src/main/scala/com/rallyhealth/weejson/v1/jackson/FromJson.scala
+++ b/weejson-jackson/src/main/scala/com/rallyhealth/weejson/v1/jackson/FromJson.scala
@@ -99,9 +99,13 @@ class JsonFromInput(parser: JsonParser) extends FromInput {
       case ID_EMBEDDED_OBJECT =>
         copyStackSafe(v)
       case ID_STRING =>
-        val start = p.getTextOffset
-        val end = start + p.getTextLength
-        val cs = new runtime.ArrayCharSequence(p.getTextCharacters, start, end)
+        val cs: CharSequence =
+          if (p.getTextLength == 0) ""
+          else {
+            val start = p.getTextOffset
+            val end = start + p.getTextLength
+            new runtime.ArrayCharSequence(p.getTextCharacters, start, end)
+          }
         v.visitString(cs)
       case ID_FIELD_NAME =>
         v.visitString(p.getCurrentName)

--- a/weejson/src/main/scala/com/rallyhealth/weejson/v1/BufferedValue.scala
+++ b/weejson/src/main/scala/com/rallyhealth/weejson/v1/BufferedValue.scala
@@ -159,9 +159,15 @@ object BufferedValue extends Transformer[BufferedValue] {
 
   case class Str(value0: String) extends BufferedValue
 
-  case class Obj(value0: (String, BufferedValue)*) extends BufferedValue
+  case class Obj(value0: (String, BufferedValue)*) extends BufferedValue {
 
-  case class Arr(value: BufferedValue*) extends BufferedValue
+    override def toString: String = value0.map { case (k, v) => s""""$k": $v""" }.mkString("Obj(", ", ", ")")
+  }
+
+  case class Arr(value: BufferedValue*) extends BufferedValue {
+
+    override def toString: String = value.mkString("Arr(", ", ", ")")
+  }
 
   sealed trait AnyNum extends BufferedValue {
     def value: BigDecimal

--- a/weejson/src/test/scala/com/rallyhealth/weejson/v1/CanonicalizeNumsVisitor.scala
+++ b/weejson/src/test/scala/com/rallyhealth/weejson/v1/CanonicalizeNumsVisitor.scala
@@ -1,0 +1,74 @@
+package com.rallyhealth.weejson.v1
+
+import com.rallyhealth.weepickle.v1.core.Visitor.{ArrDelegate, ObjDelegate}
+import com.rallyhealth.weepickle.v1.core.{ArrVisitor, ObjVisitor, Visitor}
+
+import scala.language.implicitConversions
+
+object CanonicalizeNumsVisitor {
+
+  implicit class RichVisitor[T, J](val visitor: Visitor[T, J]) extends AnyVal {
+
+    def canonicalize: Visitor[T, J] = new CanonicalizeNumsVisitor[T, J](visitor)
+  }
+}
+
+/**
+  * Forces numbers to their smallest possible representations
+  * for reproducible tests.
+  */
+class CanonicalizeNumsVisitor[T, J](underlying: Visitor[T, J])
+  extends Visitor.Delegate[T, J](underlying) {
+  import CanonicalizeNumsVisitor.RichVisitor
+
+  override def visitObject(length: Int): ObjVisitor[T, J] =
+    new ObjDelegate[T, J](underlying.visitObject(length).narrow) {
+
+      override def visitKey(): Visitor[_, _] = super.visitKey().canonicalize
+
+      override def subVisitor: Visitor[Nothing, Any] = super.subVisitor.asInstanceOf[Visitor[Any, Any]].canonicalize
+    }
+
+  override def visitArray(length: Int): ArrVisitor[T, J] =
+    new ArrDelegate[T, J](underlying.visitArray(length).narrow) {
+      override def subVisitor: Visitor[Nothing, Any] = super.subVisitor.asInstanceOf[Visitor[Any, Any]].canonicalize
+    }
+
+  override def visitFloat32(f: Float): J = {
+    val l = f.toLong
+    if (l == f) visitInt64(l)
+    else super.visitFloat32(f)
+  }
+
+  override def visitFloat64(d: Double): J = {
+    val l = d.toLong
+    val f = d.toFloat
+    if (l == d) visitInt64(l)
+    else if (f == d) visitFloat32(f)
+    else super.visitFloat64(d)
+  }
+
+  override def visitInt64(l: Long): J = {
+    val i = l.toInt
+    if (i == l) visitInt32(i)
+    else super.visitFloat64(l)
+  }
+
+  override def visitFloat64String(s: String): J = {
+    val d = BigDecimal(s)
+    if (d.isValidLong) visitInt64(d.longValue)
+    else if (d.isDecimalDouble) visitFloat64(d.doubleValue)
+    else super.visitFloat64String(s)
+  }
+
+  override def visitFloat64StringParts(
+    cs: CharSequence,
+    decIndex: Int,
+    expIndex: Int
+  ): J = {
+    val d = BigDecimal(cs.toString)
+    if (d.isValidLong) visitInt64(d.longValue)
+    else if (d.isDecimalDouble) visitFloat64(d.doubleValue)
+    else super.visitFloat64StringParts(cs, decIndex, expIndex)
+  }
+}

--- a/weejson/src/test/scala/com/rallyhealth/weejson/v1/CanonicalizeNumsVisitor.scala
+++ b/weejson/src/test/scala/com/rallyhealth/weejson/v1/CanonicalizeNumsVisitor.scala
@@ -51,7 +51,7 @@ class CanonicalizeNumsVisitor[T, J](underlying: Visitor[T, J])
   override def visitInt64(l: Long): J = {
     val i = l.toInt
     if (i == l) visitInt32(i)
-    else super.visitFloat64(l)
+    else super.visitInt64(l)
   }
 
   override def visitFloat64String(s: String): J = {

--- a/weejson/src/test/scala/com/rallyhealth/weejson/v1/CanonicalizeNumsVisitor.scala
+++ b/weejson/src/test/scala/com/rallyhealth/weejson/v1/CanonicalizeNumsVisitor.scala
@@ -15,7 +15,7 @@ object CanonicalizeNumsVisitor {
 
 /**
   * Forces numbers to their smallest possible representations
-  * for reproducible tests.
+  * for better equivalence in test assertions.
   */
 class CanonicalizeNumsVisitor[T, J](underlying: Visitor[T, J])
   extends Visitor.Delegate[T, J](underlying) {

--- a/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/ParserSpec.scala
+++ b/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/ParserSpec.scala
@@ -1,5 +1,6 @@
 package com.rallyhealth.weepickle.v1
 
+import com.rallyhealth.weejson.v1.CanonicalizeNumsVisitor._
 import com.rallyhealth.weejson.v1.jackson.{FromJson, ToJson, ToPrettyJson}
 import com.rallyhealth.weejson.v1.{BufferedValue, GenBufferedValue}
 import com.rallyhealth.weepickle.v1.core.FromInput
@@ -20,6 +21,10 @@ abstract class ParserSpec(parse: Array[Byte] => FromInput, depthLimit: Int = 100
   import com.rallyhealth.weejson.v1.BufferedValue._
   import com.rallyhealth.weejson.v1.BufferedValueOps._
 
+  override implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(
+    minSuccessful = 500
+  )
+
   private implicit def toBytes(s: String): Array[Byte] = s.getBytes
 
   "roundtrip" in testJson()
@@ -37,7 +42,7 @@ abstract class ParserSpec(parse: Array[Byte] => FromInput, depthLimit: Int = 100
       testInput(s"\n $expected \n ")
       testInput(value.transform(ToPrettyJson.bytes))
 
-      assert(parse(expected.getBytes()).transform(BufferedValue.Builder) === value)
+      assert(parse(expected.getBytes()).transform(BufferedValue.Builder.canonicalize) === value)
     }
   }
 


### PR DESCRIPTION
## loss of precision for non-double floating point numbers
The jackson-core JSON parser has been returning `NumberType.DOUBLE` for all floating point numbers for the past 10 years (never `FLOAT` or `BIGDECIMAL`). Our code misinterpreted this to mean it was safe to ask for a `double`, which has resulted in loss of precision when parsing JSON floating point numbers that don't fit into doubles. (The jackson-dataformats-binary parsers probably return accurate `NumberType`s.) https://github.com/FasterXML/jackson-core/issues/730

Since it's non-trivial to determine if a UTF-8 string should be `double` or `BigDecimal`, the fix is to toss the number in a `String` and let the downstream `Visitor` figure it out later if they want to.

## Stack-based
The new implementation uses the stack for tracking `Obj`/`ArrVisitor` up to a fixed depth, then falls back on the old slower, but stack-safe implementation. New implementation seems faster overall for my real-world data set, but not the contrived benchmarks here. Performance is highly dependent on input.

[Benchmarks by JSON file](https://jmh.morethan.io/?source=https://gist.githubusercontent.com/htmldoug/7d3fa74cf27ec0cf8f71efbc66acbb2c/raw/8977fe62f75bec3e46ac996efed5c09486f08ba1/gistfile1.txt). `JacksonStack` is the implementation in this PR.