### PR TITLE
Add weejson-jsoniter-scala

### DIFF
--- a/bench/src/main/scala/bench/JsoniterScalaBench.scala
+++ b/bench/src/main/scala/bench/JsoniterScalaBench.scala
@@ -7,31 +7,30 @@ import org.openjdk.jmh.annotations._
 import java.util.concurrent.TimeUnit
 
 /**
+  * Quick and dirty test to see how badly we're butchering performance of floats.
+  *
   * ==Quick Run==
-  * bench / Jmh / run -f1 -wi 2 -i 3 .*JsoniterScalabench
+  * bench / Jmh / run .*JsoniterScalabench
   *
   * ==Profile with Flight Recorder==
-  * bench / Jmh / run -prof jfr -f1 .*JsoniterScalabench
+  * bench / Jmh / run -prof jfr .*JsoniterScalabench
   *
   * ==Jmh Visualizer Report==
   * bench / Jmh / run -prof gc -rf json -rff JsoniterScalabench-results.json .*JsoniterScalabench
-  *
-  * ==Sample Results==
-  * {{{
-  * TODO
-  * }}}
   *
   * @see https://github.com/ktoso/sbt-jmh
   */
 @Warmup(iterations = 15, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 15, time = 1, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Benchmark)
-@BenchmarkMode(Array(Mode.Throughput)) // or @BenchmarkMode(Array(Mode.AverageTime))
+@BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(jvmArgsAppend =
-        Array("-Xmx350m", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:-BackgroundCompilation", "-XX:-TieredCompilation"),
-      value = 1)
-class JsoniterScalabench {
+@Fork(
+  jvmArgsAppend =
+    Array("-Xmx350m", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:-BackgroundCompilation", "-XX:-TieredCompilation"),
+  value = 1
+)
+class JsoniterScalaBench {
   private val input = "348249875e105".getBytes()
 
   @Benchmark

--- a/bench/src/main/scala/bench/JsoniterScalaBench.scala
+++ b/bench/src/main/scala/bench/JsoniterScalaBench.scala
@@ -1,7 +1,7 @@
 package bench
 
+import com.rallyhealth.weejson.v1.BufferedValue
 import com.rallyhealth.weejson.v1.wee_jsoniter_scala.FromJsoniterScala
-import com.rallyhealth.weepickle.v1.WeePickle.ToScala
 import org.openjdk.jmh.annotations._
 
 import java.util.concurrent.TimeUnit
@@ -10,17 +10,17 @@ import java.util.concurrent.TimeUnit
   * Quick and dirty test to see how badly we're butchering performance of floats.
   *
   * ==Quick Run==
-  * bench / Jmh / run .*JsoniterScalabench
+  * bench / Jmh / run .*JsoniterScalaBench
   *
   * ==Profile with Flight Recorder==
-  * bench / Jmh / run -prof jfr .*JsoniterScalabench
+  * bench / Jmh / run -prof jfr .*JsoniterScalaBench
   *
   * ==Jmh Visualizer Report==
-  * bench / Jmh / run -prof gc -rf json -rff JsoniterScalabench-results.json .*JsoniterScalabench
+  * bench / Jmh / run -prof gc -rf json -rff JsoniterScalaBench-results.json .*JsoniterScalaBench
   *
   * @see https://github.com/ktoso/sbt-jmh
   */
-@Warmup(iterations = 15, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 15, time = 1, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.Throughput))
@@ -31,11 +31,15 @@ import java.util.concurrent.TimeUnit
   value = 1
 )
 class JsoniterScalaBench {
-  private val input = "348249875e105".getBytes()
+
+  /**
+    * Values that end with a number throw an expensive exception internally when reaching EOF.
+    * The only time this would happen in the wild would be when parsing a JSON text of a single number.
+    * To make this more realistic, we're intentionally adding a whitespace suffix here.
+    */
+  private val piBytes = "-3.14 ".getBytes()
 
   @Benchmark
-  def parseDouble = {
-    FromJsoniterScala(input).transform(ToScala[Double])
-  }
+  def pi = FromJsoniterScala(piBytes).transform(BufferedValue.Builder)
 
 }

--- a/bench/src/main/scala/bench/JsoniterScalaBench.scala
+++ b/bench/src/main/scala/bench/JsoniterScalaBench.scala
@@ -37,9 +37,12 @@ class JsoniterScalaBench {
     * The only time this would happen in the wild would be when parsing a JSON text of a single number.
     * To make this more realistic, we're intentionally adding a whitespace suffix here.
     */
-  private val piBytes = "-3.14 ".getBytes()
+  private val floatBytes = "-3.14159 ".getBytes()
+  private val intBytes = "186282 ".getBytes()
 
   @Benchmark
-  def pi = FromJsoniterScala(piBytes).transform(BufferedValue.Builder)
+  def parseFloat = FromJsoniterScala(floatBytes).transform(BufferedValue.Builder)
 
+  @Benchmark
+  def parseInt = FromJsoniterScala(intBytes).transform(BufferedValue.Builder)
 }

--- a/bench/src/main/scala/bench/JsoniterScalabench.scala
+++ b/bench/src/main/scala/bench/JsoniterScalabench.scala
@@ -1,0 +1,42 @@
+package bench
+
+import com.rallyhealth.weejson.v1.wee_jsoniter_scala.FromJsoniterScala
+import com.rallyhealth.weepickle.v1.WeePickle.ToScala
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+
+/**
+  * ==Quick Run==
+  * bench / Jmh / run -f1 -wi 2 -i 3 .*JsoniterScalabench
+  *
+  * ==Profile with Flight Recorder==
+  * bench / Jmh / run -prof jfr -f1 .*JsoniterScalabench
+  *
+  * ==Jmh Visualizer Report==
+  * bench / Jmh / run -prof gc -rf json -rff JsoniterScalabench-results.json .*JsoniterScalabench
+  *
+  * ==Sample Results==
+  * {{{
+  * TODO
+  * }}}
+  *
+  * @see https://github.com/ktoso/sbt-jmh
+  */
+@Warmup(iterations = 15, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 15, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput)) // or @BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(jvmArgsAppend =
+        Array("-Xmx350m", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:-BackgroundCompilation", "-XX:-TieredCompilation"),
+      value = 1)
+class JsoniterScalabench {
+  private val input = "348249875e105".getBytes()
+
+  @Benchmark
+  def parseDouble = {
+    FromJsoniterScala(input).transform(ToScala[Double])
+  }
+
+}

--- a/bench/src/test/scala/bench/JsoniterScalaBenchTests.scala
+++ b/bench/src/test/scala/bench/JsoniterScalaBenchTests.scala
@@ -1,0 +1,12 @@
+package bench
+
+import com.rallyhealth.weejson.v1.BufferedValue._
+import utest._
+
+object JsoniterScalaBenchTests extends TestSuite {
+
+  val tests = Tests {
+    val bench = new JsoniterScalaBench()
+    test("pi")(bench.pi ==> Num("-3.14", 2, -1))
+  }
+}

--- a/bench/src/test/scala/bench/JsoniterScalaBenchTests.scala
+++ b/bench/src/test/scala/bench/JsoniterScalaBenchTests.scala
@@ -7,6 +7,7 @@ object JsoniterScalaBenchTests extends TestSuite {
 
   val tests = Tests {
     val bench = new JsoniterScalaBench()
-    test("pi")(bench.pi ==> Num("-3.14", 2, -1))
+    test("parseFloat")(bench.parseFloat ==> Num("-3.14159", 2, -1))
+    test("parseInt")(bench.parseInt ==> NumLong(186282))
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -95,6 +95,7 @@ lazy val `weepickle-tests` = project
     `weejson-argonaut`,
     `weejson-circe`,
     `weejson-json4s`,
+    `weejson-jsoniter-scala`,
     `weejson-play-base`,
     `weejson` % "compile;test->test",
     `weepack` % "compile;test->test",

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ lazy val bench = project
   .dependsOn(
     `weepickle-tests` % "compile;test",
     `weejson-upickle`,
+    `weejson-jsoniter-scala`,
   )
   .enablePlugins(JmhPlugin)
   .settings(
@@ -135,6 +136,27 @@ lazy val `weejson-jackson` = project
     mimaBinaryIssueFilters ++= Seq(
       ProblemFilters.exclude[DirectMissingMethodProblem]("com.rallyhealth.weejson.v1.jackson.TextBufferCharSequence.isEmpty")
     )
+  )
+
+/**
+  * A very fast JSON parser.
+  *
+  * Uses MiMa, but not shaded. Package naming strategy across major versions is unknown.
+  *
+  * @see https://github.com/plokhotnyuk/jsoniter-scala
+  */
+lazy val `weejson-jsoniter-scala` = project
+  .dependsOn(`weepickle-core`)
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.12.0"
+    ),
+    mimaPreviousArtifacts := {
+      if (VersionNumber(version.value).matchesSemVer(SemanticSelector("<1.8.0")))
+        Set.empty
+      else
+        mimaPreviousArtifacts.value
+    }
   )
 
 lazy val `weejson-circe` = project

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.9.2")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")

--- a/weejson-jsoniter-scala/src/main/scala/com/rallyhealth/weejson/v1/wee_jsoniter_scala/FromJsoniterScala.scala
+++ b/weejson-jsoniter-scala/src/main/scala/com/rallyhealth/weejson/v1/wee_jsoniter_scala/FromJsoniterScala.scala
@@ -17,7 +17,10 @@ import java.nio.ByteBuffer
   *
   * @see https://github.com/plokhotnyuk/jsoniter-scala
   */
-object FromJsoniterScala extends FromJsoniterScala(ReaderConfig)
+object FromJsoniterScala extends FromJsoniterScala(
+  ReaderConfig
+    .withAppendHexDumpToParseException(false) // avoid leaking sensitive plaintext data
+)
 
 class FromJsoniterScala(config: ReaderConfig) {
 

--- a/weejson-jsoniter-scala/src/main/scala/com/rallyhealth/weejson/v1/wee_jsoniter_scala/FromJsoniterScala.scala
+++ b/weejson-jsoniter-scala/src/main/scala/com/rallyhealth/weejson/v1/wee_jsoniter_scala/FromJsoniterScala.scala
@@ -1,0 +1,54 @@
+package com.rallyhealth.weejson.v1.wee_jsoniter_scala
+
+import com.github.plokhotnyuk.jsoniter_scala.core._
+import com.rallyhealth.weejson.v1.wee_jsoniter_scala.WeePickleJsonValueCodecs.VisitorJsonValueEncoder
+import com.rallyhealth.weepickle.v1.core.{FromInput, Visitor}
+
+import java.io.InputStream
+import java.nio.ByteBuffer
+
+/**
+  * A very fast UTF-8-only JSON parser.
+  *
+  * This integration:
+  *  - tracks paths and returns as JsonPointer
+  *  - does not deduplicate strings
+  *  - throws below a fixed depth limit
+  *
+  * @see https://github.com/plokhotnyuk/jsoniter-scala
+  */
+object FromJsoniterScala extends FromJsoniterScala(ReaderConfig)
+
+class FromJsoniterScala(config: ReaderConfig) {
+
+  def apply(
+    bytes: Array[Byte]
+  ): FromInput = new FromInput {
+
+    override def transform[T](
+      to: Visitor[_, T]
+    ): T = readFromArray(bytes, config)(readerCodec(to))
+  }
+
+  def apply(
+    in: InputStream
+  ): FromInput = new FromInput {
+
+    override def transform[T](
+      to: Visitor[_, T]
+    ): T = readFromStream(in, config)(readerCodec(to))
+  }
+
+  def apply(
+    buf: ByteBuffer
+  ): FromInput = new FromInput {
+
+    override def transform[T](
+      to: Visitor[_, T]
+    ): T = readFromByteBuffer(buf, config)(readerCodec(to))
+  }
+
+  private def readerCodec[J](
+    v: Visitor[_, J]
+  ): JsonValueCodec[J] = new VisitorJsonValueEncoder[J](v, maxDepth = 64)
+}

--- a/weejson-jsoniter-scala/src/main/scala/com/rallyhealth/weejson/v1/wee_jsoniter_scala/FromJsoniterScala.scala
+++ b/weejson-jsoniter-scala/src/main/scala/com/rallyhealth/weejson/v1/wee_jsoniter_scala/FromJsoniterScala.scala
@@ -11,9 +11,9 @@ import java.nio.ByteBuffer
   * A very fast UTF-8-only JSON parser.
   *
   * This integration:
-  *  - tracks paths and returns as JsonPointer
-  *  - does not deduplicate strings
-  *  - throws below a fixed depth limit
+  *  - tracks paths and returns a JsonPointer on error
+  *  - does not deduplicate string keys (as jackson-core does)
+  *  - throws when a fixed depth limit is reached
   *
   * @see https://github.com/plokhotnyuk/jsoniter-scala
   */

--- a/weejson-jsoniter-scala/src/main/scala/com/rallyhealth/weejson/v1/wee_jsoniter_scala/JsonWriterVisitor.scala
+++ b/weejson-jsoniter-scala/src/main/scala/com/rallyhealth/weejson/v1/wee_jsoniter_scala/JsonWriterVisitor.scala
@@ -135,7 +135,10 @@ class JsonWriterVisitor(
     offset: Int,
     len: Int
   ): JsonWriter = {
-    val trimmed = if (bytes.length != len) bytes.take(len) else bytes
+    val trimmed =
+      if (offset == 0 && bytes.length <= len) bytes
+      else bytes.slice(offset, offset + len)
+
     writer.writeBase64Val(trimmed, true)
     writer
   }

--- a/weejson-jsoniter-scala/src/main/scala/com/rallyhealth/weejson/v1/wee_jsoniter_scala/JsonWriterVisitor.scala
+++ b/weejson-jsoniter-scala/src/main/scala/com/rallyhealth/weejson/v1/wee_jsoniter_scala/JsonWriterVisitor.scala
@@ -1,0 +1,142 @@
+package com.rallyhealth.weejson.v1.wee_jsoniter_scala
+
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonWriter
+import com.rallyhealth.weepickle.v1.core._
+
+import java.time.Instant
+
+class JsonWriterVisitor(
+  writer: JsonWriter
+) extends JsVisitor[Any, JsonWriter] {
+
+  private[this] val arrVisitor = new ArrVisitor[Any, JsonWriter] {
+    override def subVisitor: Visitor[_, _] = JsonWriterVisitor.this
+
+    override def visitValue(
+      v: Any
+    ): Unit = ()
+
+    override def visitEnd(): JsonWriter = {
+      writer.writeArrayEnd()
+      writer
+    }
+  }
+
+  private[this] val objVisitor = new ObjVisitor[Any, JsonWriter] {
+    writer.writeObjectStart()
+    override def visitKey(): Visitor[_, _] = StringVisitor
+
+    override def visitKeyValue(
+      v: Any
+    ): Unit = writer.writeKey(v.toString)
+
+    override def subVisitor: Visitor[_, _] = JsonWriterVisitor.this
+
+    override def visitValue(
+      v: Any
+    ): Unit = ()
+
+    override def visitEnd(): JsonWriter = {
+      writer.writeObjectEnd()
+      writer
+    }
+  }
+
+  override def visitArray(
+    length: Int
+  ): ArrVisitor[Any, JsonWriter] = arrVisitor
+
+  override def visitObject(
+    length: Int
+  ): ObjVisitor[Any, JsonWriter] = objVisitor
+
+  override def visitNull(): JsonWriter = {
+    writer.writeNull()
+    writer
+  }
+
+  override def visitFalse(): JsonWriter = {
+    writer.writeVal(false)
+    writer
+  }
+
+  override def visitTrue(): JsonWriter = {
+    writer.writeVal(true)
+    writer
+  }
+
+  override def visitFloat64StringParts(
+    cs: CharSequence,
+    decIndex: Int,
+    expIndex: Int
+  ): JsonWriter = {
+    writer.writeNonEscapedAsciiVal(cs.toString)
+    writer
+  }
+
+  override def visitFloat64(
+    d: Double
+  ): JsonWriter = {
+    writer.writeVal(d)
+    writer
+  }
+
+  override def visitFloat32(
+    d: Float
+  ): JsonWriter = {
+    writer.writeVal(d)
+    writer
+  }
+
+  override def visitInt32(
+    i: Int
+  ): JsonWriter = {
+    writer.writeVal(i)
+    writer
+  }
+
+  override def visitInt64(
+    l: Long
+  ): JsonWriter = {
+    writer.writeVal(l)
+    writer
+  }
+
+  override def visitFloat64String(
+    s: String
+  ): JsonWriter = {
+    writer.writeNonEscapedAsciiVal(s)
+    writer
+  }
+
+  override def visitString(
+    cs: CharSequence
+  ): JsonWriter = {
+    writer.writeVal(cs.toString)
+    writer
+  }
+
+  override def visitChar(
+    c: Char
+  ): JsonWriter = {
+    writer.writeVal(c)
+    writer
+  }
+
+  override def visitTimestamp(
+    instant: Instant
+  ): JsonWriter = {
+    writer.writeVal(instant)
+    writer
+  }
+
+  override def visitBinary(
+    bytes: Array[Byte],
+    offset: Int,
+    len: Int
+  ): JsonWriter = {
+    val trimmed = if (bytes.length != len) bytes.take(len) else bytes
+    writer.writeBase64Val(trimmed, true)
+    writer
+  }
+}

--- a/weejson-jsoniter-scala/src/main/scala/com/rallyhealth/weejson/v1/wee_jsoniter_scala/WeePickleJsonValueCodecs.scala
+++ b/weejson-jsoniter-scala/src/main/scala/com/rallyhealth/weejson/v1/wee_jsoniter_scala/WeePickleJsonValueCodecs.scala
@@ -1,0 +1,178 @@
+package com.rallyhealth.weejson.v1.wee_jsoniter_scala
+
+import com.github.plokhotnyuk.jsoniter_scala.core.{JsonReader, JsonReaderException, JsonValueCodec, JsonWriter}
+import com.rallyhealth.weepickle.v1.core.JsonPointerVisitor.JsonPointerException
+import com.rallyhealth.weepickle.v1.core.{FromInput, Types, Visitor}
+
+import java.nio.charset.StandardCharsets
+import scala.util.control.{NoStackTrace, NonFatal}
+
+object WeePickleJsonValueCodecs {
+
+  implicit object FromInputJsonValueEncoder extends JsonValueCodec[FromInput] {
+
+    override def decodeValue(
+      in: JsonReader,
+      default: FromInput
+    ): FromInput = throw new UnsupportedOperationException(
+      "only supports encoding"
+    )
+
+    override def encodeValue(
+      fromInput: FromInput,
+      out: JsonWriter
+    ): Unit = {
+      fromInput.transform(new JsonWriterVisitor(out))
+    }
+
+    override def nullValue: FromInput = null
+  }
+
+  private case class JsonPathParts(
+    pointer: List[String],
+    cause: Throwable
+  ) extends RuntimeException(cause)
+    with NoStackTrace {
+
+    override def getMessage: String = pointer.mkString("/")
+  }
+
+  class VisitorJsonValueEncoder[J](
+    v: Visitor[_, J],
+    maxDepth: Int = 64
+  ) extends JsonValueCodec[J] {
+
+    override def decodeValue(
+      in: JsonReader,
+      default: J
+    ): J = {
+      try {
+        decodeValue(in, v, maxDepth)
+      } catch {
+        case JsonPathParts(pointer, cause) =>
+          val jsonPointer = pointer.view
+            .map(_.replace("~", "~0").replace("/", "~1"))
+            .mkString("/", "/", "")
+          throw new JsonPointerException(jsonPointer, cause)
+        case NonFatal(t) =>
+          throw new JsonPointerException("", t)
+      }
+    }
+
+    private def decodeValue[TT, JJ](
+      in: JsonReader,
+      v: Visitor[_, JJ],
+      depth: Int
+    ): JJ = {
+      val b = in.nextToken()
+
+      if (b == '"') {
+        in.rollbackToken()
+        v.visitString(in.readString(null))
+      } else if (b == 't' || b == 'f') {
+        in.rollbackToken()
+        if (in.readBoolean()) v.visitTrue() else v.visitFalse()
+      } else if ((b >= '0' && b <= '9') || b == '-') {
+        in.rollbackToken()
+        parseNumber(in, v)
+      } else if (b == '[') {
+        val depthM1 = depth - 1
+        if (depthM1 < 0) in.decodeError("depth limit exceeded")
+        val isEmpty = in.isNextToken(']')
+        var i = 0
+        val arr = v.visitArray(if (isEmpty) 0 else -1).narrow
+        try {
+          if (!isEmpty) {
+            in.rollbackToken()
+            while ({
+              arr.visitValue(decodeValue(in, arr.subVisitor, depthM1))
+              i += 1
+              in.isNextToken(',')
+            }) ()
+            if (!in.isCurrentToken(']')) in.arrayEndOrCommaError()
+          }
+        } catch {
+          case NonFatal(t) => prependFailurePathInfo(t, String.valueOf(i))
+        }
+        arr.visitEnd()
+      } else if (b == '{') {
+        val depthM1 = depth - 1
+        if (depthM1 < 0) in.decodeError("depth limit exceeded")
+        val isEmpty = in.isNextToken('}')
+        val obj = v.visitObject(if (isEmpty) 0 else -1).narrow
+        if (!isEmpty) {
+          in.rollbackToken()
+          var key: String = "?"
+          try {
+            while ( {
+              key = in.readKeyAsString()
+              obj.visitKeyValue(obj.visitKey().visitString(key))
+              obj.visitValue(decodeValue(in, obj.subVisitor, depthM1))
+              in.isNextToken(',')
+            }) ()
+            if (!in.isCurrentToken('}')) in.objectEndOrCommaError()
+          } catch {
+            case NonFatal(t) => prependFailurePathInfo(t, key)
+          }
+        }
+        obj.visitEnd()
+      } else {
+        in.readNullOrError(v.visitNull(), "expected `null` value")
+      }
+    }
+
+    private def parseNumber[J](
+      in: JsonReader,
+      v: Visitor[_, J]
+    ): J = {
+      in.setMark()
+      var digits = 0
+      var b = in.nextByte()
+      if (b == '-') b = in.nextByte()
+      try {
+        while (b >= '0' && b <= '9') {
+          b = in.nextByte()
+          digits += 1
+        }
+      } catch {
+        case _: JsonReaderException => // ignore the end of input error for now
+      }
+      finally in.rollbackToMark()
+
+      if ((b | 0x20) != 'e' && b != '.') {
+        if (digits < 19) {
+          val l = in.readLong()
+          val i = l.toInt
+          if (l == i) v.visitInt32(i)
+          else v.visitInt64(l)
+        } else {
+          // TODO what happens with `123foobar`?
+          val str = new String(in.readRawValAsBytes(), StandardCharsets.US_ASCII)
+          v.visitFloat64StringParts(str, -1, -1)
+        }
+      } else {
+        // TODO find decIndex and expIndex for visitFloat64StringParts(). We're already close.
+        val str = new String(in.readRawValAsBytes(), StandardCharsets.US_ASCII)
+        v.visitFloat64String(str)
+      }
+    }
+
+    private def prependFailurePathInfo(
+      t: Throwable,
+      pathSegment: String
+    ): Nothing = t match {
+      case JsonPathParts(pointer, cause) =>
+        throw JsonPathParts(pathSegment :: pointer, cause)
+      case other: Throwable => throw JsonPathParts(pathSegment :: Nil, other)
+    }
+
+    override def nullValue: J = null.asInstanceOf[J] // unused
+
+    override def encodeValue(
+      x: J,
+      out: JsonWriter
+    ): Unit = {
+      throw new UnsupportedOperationException("only supports decoding")
+    }
+  }
+}

--- a/weejson-jsoniter-scala/src/main/scala/com/rallyhealth/weejson/v1/wee_jsoniter_scala/WeePickleJsonValueCodecs.scala
+++ b/weejson-jsoniter-scala/src/main/scala/com/rallyhealth/weejson/v1/wee_jsoniter_scala/WeePickleJsonValueCodecs.scala
@@ -171,7 +171,7 @@ object WeePickleJsonValueCodecs {
           * trailing hyphens.
           *
           */
-        require(ValidJsonNum.matches(cs), "invalid number")
+        require(ValidJsonNum.pattern.matcher(cs).matches(), "invalid number")
         v.visitFloat64String(cs)
       }
     }

--- a/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/NumberSoup.scala
+++ b/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/NumberSoup.scala
@@ -3,27 +3,37 @@ package com.rallyhealth.weepickle.v1
 import com.rallyhealth.weepickle.v1.NumberSoup.ValidJsonNum
 import org.scalacheck.{Arbitrary, Gen}
 
+/**
+  * @param value some random concatenation of number-related characters that may or may not be a valid number.
+  */
 case class NumberSoup(value: String) {
 
-  override def toString: String = value
+  override def toString: String = s""""$value""""
 
-  def isValid: Boolean = ValidJsonNum.pattern.matcher(value).matches()
+  def isValidJson: Boolean = ValidJsonNum.pattern.matcher(value).matches()
 
-  def isInvalid: Boolean = !isValid
+  def isInvalidJson: Boolean = !isValidJson
 }
 object NumberSoup {
-  val ValidJsonNum = """-?(0|[1-9]\d*)(\.\d+)?([eE][-+]?\d+)?""".r // based on https://datatracker.ietf.org/doc/html/rfc7159#page-6
+  val ValidJsonNum = """\s*-?(0|[1-9]\d*)(\.\d+)?([eE][-+]?\d+)?\s*""".r // based on https://datatracker.ietf.org/doc/html/rfc7159#page-6
 
   implicit val gen: Gen[NumberSoup] = {
+    val maybeSpace = Gen.option(Gen.oneOf(" ", "  ", "\n"))
     val numberParts = Gen.frequency(
       1 -> Gen.numStr,
       1 -> ".",
       1 -> "-",
       1 -> "+",
       1 -> "E",
-      1 -> "e"
+      1 -> "e",
+      1 -> "0",
+      1 -> " "
     )
-    Gen.listOf(numberParts).map(_.mkString).map(NumberSoup(_))
+    for {
+      prefix <- maybeSpace
+      parts <- Gen.listOf(numberParts).map(_.mkString)
+      suffix <- maybeSpace
+    } yield NumberSoup(s"$prefix$parts$suffix")
   }
   implicit val arb: Arbitrary[NumberSoup] = Arbitrary(gen)
 }

--- a/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/NumberSoup.scala
+++ b/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/NumberSoup.scala
@@ -1,10 +1,15 @@
 package com.rallyhealth.weepickle.v1
 
+import com.rallyhealth.weepickle.v1.NumberSoup.ValidJsonNum
 import org.scalacheck.{Arbitrary, Gen}
 
 case class NumberSoup(value: String) {
 
   override def toString: String = value
+
+  def isValid: Boolean = ValidJsonNum.pattern.matcher(value).matches()
+
+  def isInvalid: Boolean = !isValid
 }
 object NumberSoup {
   val ValidJsonNum = """-?(0|[1-9]\d*)(\.\d+)?([eE][-+]?\d+)?""".r // based on https://datatracker.ietf.org/doc/html/rfc7159#page-6
@@ -16,7 +21,7 @@ object NumberSoup {
       1 -> "-",
       1 -> "+",
       1 -> "E",
-      1 -> "e",
+      1 -> "e"
     )
     Gen.listOf(numberParts).map(_.mkString).map(NumberSoup(_))
   }

--- a/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/NumberSoup.scala
+++ b/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/NumberSoup.scala
@@ -1,0 +1,24 @@
+package com.rallyhealth.weepickle.v1
+
+import org.scalacheck.{Arbitrary, Gen}
+
+case class NumberSoup(value: String) {
+
+  override def toString: String = value
+}
+object NumberSoup {
+  val ValidJsonNum = """-?(0|[1-9]\d*)(\.\d+)?([eE][-+]?\d+)?""".r // based on https://datatracker.ietf.org/doc/html/rfc7159#page-6
+
+  implicit val gen: Gen[NumberSoup] = {
+    val numberParts = Gen.frequency(
+      1 -> Gen.numStr,
+      1 -> ".",
+      1 -> "-",
+      1 -> "+",
+      1 -> "E",
+      1 -> "e",
+    )
+    Gen.listOf(numberParts).map(_.mkString).map(NumberSoup(_))
+  }
+  implicit val arb = Arbitrary(gen)
+}

--- a/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/NumberSoup.scala
+++ b/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/NumberSoup.scala
@@ -25,5 +25,5 @@ object NumberSoup {
     )
     Gen.listOf(numberParts).map(_.mkString).map(NumberSoup(_))
   }
-  implicit val arb = Arbitrary(gen)
+  implicit val arb: Arbitrary[NumberSoup] = Arbitrary(gen)
 }

--- a/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/ParserSpec.scala
+++ b/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/ParserSpec.scala
@@ -1,6 +1,5 @@
 package com.rallyhealth.weepickle.v1
 
-import com.github.plokhotnyuk.jsoniter_scala.core.{JsonReader, JsonValueCodec, JsonWriter, readFromArray}
 import com.rallyhealth.weejson.v1.CanonicalizeNumsVisitor._
 import com.rallyhealth.weejson.v1.jackson.{FromJson, ToJson, ToPrettyJson}
 import com.rallyhealth.weejson.v1.wee_jsoniter_scala.FromJsoniterScala
@@ -34,9 +33,9 @@ abstract class ParserSpec(parse: Array[Byte] => FromInput, depthLimit: Int = 100
   private implicit def toBytes(s: String): Array[Byte] = s.getBytes
 
   "roundtrip" in testJson()
+  "roundtrip example" in testValue(NumDouble(1.3424780377262655E-5))
   "deep arr" in testDepth(Arr(_))
   "deep obj" in testDepth(b => Obj("k" -> b))
-  "example" in testValue(NumDouble(1.3424780377262655E-5))
   "number soup" in forAll { soup: NumberSoup =>
     val isValid = ValidJsonNum.matches(soup.value)
     whenever(!isValid) {
@@ -44,25 +43,6 @@ abstract class ParserSpec(parse: Array[Byte] => FromInput, depthLimit: Int = 100
         parse(soup.value.getBytes()).transform(NoOpVisitor)
       }
     }
-  }
-  "number soup test" in {
-    val soup: NumberSoup = NumberSoup("96553560648619.1826-+.E59592860268957408.039294393856+e")
-    intercept[Exception] {
-      parse(soup.value.getBytes()).transform(NoOpVisitor)
-    }
-  }
-  "mmm" in {
-    implicit val codec = new JsonValueCodec[BigDecimal] {
-      override def decodeValue(in: JsonReader, default: BigDecimal): BigDecimal = {
-        in.readBigDecimal(null)
-      }
-
-      override def encodeValue(x: BigDecimal, out: JsonWriter): Unit = ???
-
-      override def nullValue: BigDecimal = null
-    }
-
-    readFromArray[BigDecimal]("4821954884020056889177390769786858.2839256153498221179+-")
   }
   "net/JSONTestSuite" - {
     for {

--- a/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/ParserSpec.scala
+++ b/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/ParserSpec.scala
@@ -37,8 +37,7 @@ abstract class ParserSpec(parse: Array[Byte] => FromInput, depthLimit: Int = 100
   "deep arr" in testDepth(Arr(_))
   "deep obj" in testDepth(b => Obj("k" -> b))
   "number soup" in forAll { soup: NumberSoup =>
-    val isValid = ValidJsonNum.matches(soup.value)
-    whenever(!isValid) {
+    whenever(soup.isInvalid) {
       intercept[Exception] {
         parse(soup.value.getBytes()).transform(NoOpVisitor)
       }

--- a/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/ParserSpec.scala
+++ b/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/ParserSpec.scala
@@ -109,15 +109,13 @@ class FromJsonInputStreamSpec extends ParserSpec(b => FromJson(new ByteArrayInpu
 
 class FromJsonReaderSpec extends ParserSpec(b => FromJson(new StringReader(new String(b))))
 
-class FromJsonPathSpec
-    extends ParserSpec(
-      b => FromJson(Files.write(Files.createTempFile("FromJsonPathSpec", ".json"), b))
-    )
+class FromJsonPathSpec extends ParserSpec(
+  b => FromJson(Files.write(Files.createTempFile("FromJsonPathSpec", ".json"), b))
+)
 
-class FromJsonFileSpec
-    extends ParserSpec(
-      b => FromJson(Files.write(Files.createTempFile("FromJsonFileSpec", ".json"), b).toFile)
-    )
+class FromJsonFileSpec extends ParserSpec(
+  b => FromJson(Files.write(Files.createTempFile("FromJsonFileSpec", ".json"), b).toFile)
+)
 
 class FromJsoniterScalaBytesSpec extends ParserSpec(FromJsoniterScala(_), 62)
 

--- a/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/ParserSpec.scala
+++ b/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/ParserSpec.scala
@@ -2,6 +2,7 @@ package com.rallyhealth.weepickle.v1
 
 import com.rallyhealth.weejson.v1.CanonicalizeNumsVisitor._
 import com.rallyhealth.weejson.v1.jackson.{FromJson, ToJson, ToPrettyJson}
+import com.rallyhealth.weejson.v1.wee_jsoniter_scala.FromJsoniterScala
 import com.rallyhealth.weejson.v1.{BufferedValue, GenBufferedValue}
 import com.rallyhealth.weepickle.v1.core.{FromInput, NoOpVisitor}
 import org.scalactic.TypeCheckedTripleEquals
@@ -9,13 +10,14 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import java.io.{ByteArrayInputStream, File, StringReader}
+import java.nio.ByteBuffer
 import java.nio.file.Files
 import scala.concurrent.duration._
 import scala.language.{existentials, implicitConversions}
 import scala.util.Try
 
 abstract class ParserSpec(parse: Array[Byte] => FromInput, depthLimit: Int = 100)
-  extends AnyFreeSpec
+    extends AnyFreeSpec
     with ScalaCheckPropertyChecks
     with GenBufferedValue
     with TypeCheckedTripleEquals {
@@ -36,8 +38,8 @@ abstract class ParserSpec(parse: Array[Byte] => FromInput, depthLimit: Int = 100
   "net/JSONTestSuite" - {
     for {
       file <- new File("weepickle-tests/src/test/test_parsing").listFiles()
-        name = file.getName
-        if name.endsWith(".json")
+      name = file.getName
+      if name.endsWith(".json")
     } {
       def parse() = FromJson(file).transform(NoOpVisitor)
 
@@ -88,11 +90,18 @@ class FromJsonInputStreamSpec extends ParserSpec(b => FromJson(new ByteArrayInpu
 
 class FromJsonReaderSpec extends ParserSpec(b => FromJson(new StringReader(new String(b))))
 
-class FromJsonPathSpec extends ParserSpec(
-  b => FromJson(Files.write(Files.createTempFile("FromJsonPathSpec", ".json"), b))
-)
+class FromJsonPathSpec
+    extends ParserSpec(
+      b => FromJson(Files.write(Files.createTempFile("FromJsonPathSpec", ".json"), b))
+    )
 
-class FromJsonFileSpec extends ParserSpec(
-  b => FromJson(Files.write(Files.createTempFile("FromJsonFileSpec", ".json"), b).toFile)
-)
+class FromJsonFileSpec
+    extends ParserSpec(
+      b => FromJson(Files.write(Files.createTempFile("FromJsonFileSpec", ".json"), b).toFile)
+    )
 
+class FromJsoniterScalaBytesSpec extends ParserSpec(FromJsoniterScala(_), 62)
+
+class FromJsoniterScalaInputStreamSpec extends ParserSpec(b => FromJsoniterScala(new ByteArrayInputStream(b)), 62)
+
+class FromJsoniterScalaByteBufferSpec extends ParserSpec(b => FromJsoniterScala(ByteBuffer.wrap(b)), 62)

--- a/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/ParserSpec.scala
+++ b/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/ParserSpec.scala
@@ -4,7 +4,6 @@ import com.rallyhealth.weejson.v1.CanonicalizeNumsVisitor._
 import com.rallyhealth.weejson.v1.jackson.{FromJson, ToJson, ToPrettyJson}
 import com.rallyhealth.weejson.v1.wee_jsoniter_scala.FromJsoniterScala
 import com.rallyhealth.weejson.v1.{BufferedValue, GenBufferedValue, Value}
-import com.rallyhealth.weepickle.v1.NumberSoup.ValidJsonNum
 import com.rallyhealth.weepickle.v1.core.{FromInput, NoOpVisitor, Visitor}
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.freespec.AnyFreeSpec
@@ -36,7 +35,7 @@ abstract class ParserSpec(parse: Array[Byte] => FromInput, depthLimit: Int = 100
   "roundtrip example" in testValue(NumDouble(1.3424780377262655E-5))
   "deep arr" in testDepth(Arr(_))
   "deep obj" in testDepth(b => Obj("k" -> b))
-  "number soup" in forAll { soup: NumberSoup =>
+  "number soup" in forAll { (soup: NumberSoup) =>
     whenever(soup.isInvalid) {
       intercept[Exception] {
         parse(soup.value.getBytes()).transform(NoOpVisitor)

--- a/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/ParserSpec.scala
+++ b/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/ParserSpec.scala
@@ -32,11 +32,10 @@ abstract class ParserSpec(parse: Array[Byte] => FromInput, depthLimit: Int = 100
   private implicit def toBytes(s: String): Array[Byte] = s.getBytes
 
   "roundtrip" in testJson()
-  "roundtrip example" in testValue(NumDouble(1.3424780377262655E-5))
   "deep arr" in testDepth(Arr(_))
   "deep obj" in testDepth(b => Obj("k" -> b))
   "number soup" in forAll { (soup: NumberSoup) =>
-    whenever(soup.isInvalid) {
+    whenever(soup.isInvalidJson) {
       intercept[Exception] {
         parse(soup.value.getBytes()).transform(NoOpVisitor)
       }


### PR DESCRIPTION
## Summary
Adds basic integration for the very fast [jsoniter-scala](https://github.com/plokhotnyuk/jsoniter-scala) parser.

## Benchmarks
- [My benchmarks on doppelganger JSON files](https://jmh.morethan.io/?source=https://gist.githubusercontent.com/htmldoug/7d3fa74cf27ec0cf8f71efbc66acbb2c/raw/8977fe62f75bec3e46ac996efed5c09486f08ba1/gistfile1.txt) with the parsers integrated into weepickle (possibly suboptimally)
- [Official jsoniter-scala benchmarks](https://plokhotnyuk.github.io/jsoniter-scala) using the JSON specialized macros instead of the weepickle macros

## Optional Jar
Based on performance alone, I'd love to have this parser as weepickle's default UTF-8 implementation, but:
1. I'm not giving up jackson-core integration (particularly for [dataformats-binary](https://github.com/FasterXML/jackson-dataformats-binary) and [dataformats-text](https://github.com/FasterXML/jackson-dataformats-text)). 
2. Having _two_ default parser dependencies is slightly "wat"
3. I'm not sure if jsoniter-scala v3 will use the same package names and cause us dependency hell. Last major version release was in [Nov 2019](https://github.com/plokhotnyuk/jsoniter-scala/releases/tag/v2.0.0) and did not change package names.)

The [README](https://github.com/plokhotnyuk/jsoniter-scala) suggests as a feature:

> Support of shading to another package for locking on a particular released version

We may want to go this route in the future, but for now, I'm adding the integration as an optional jar primarily for use by non-libraries at the absolute root of the dependency tree.

## TODO 
- [x] parse floats less horribly
- [ ] update readme