### PR TITLE
BufferedValue equality

### DIFF
--- a/weejson/src/main/scala/com/rallyhealth/weejson/v1/BufferedValue.scala
+++ b/weejson/src/main/scala/com/rallyhealth/weejson/v1/BufferedValue.scala
@@ -182,15 +182,15 @@ object BufferedValue extends Transformer[BufferedValue] {
 
   sealed trait AnyNum extends BufferedValue {
     def value: BigDecimal
+  }
+
+  case class Num(s: String, decIndex: Int, expIndex: Int) extends AnyNum {
+    override def value: BigDecimal = BigDecimal(s)
 
     override def equals(that: Any): Boolean = that match {
       case other: AnyNum => this.value == other.value
       case _ => super.equals(that)
     }
-  }
-
-  case class Num(s: String, decIndex: Int, expIndex: Int) extends AnyNum {
-    override def value: BigDecimal = BigDecimal(s)
   }
 
   case class NumLong(l: Long) extends AnyNum {
@@ -199,6 +199,7 @@ object BufferedValue extends Transformer[BufferedValue] {
     override def equals(that: Any): Boolean = that match {
       case NumLong(otherL) => this.l == otherL
       case NumDouble(otherD) => this.l.toDouble == otherD
+      case other: AnyNum => this.value == other.value
       case _ => super.equals(that)
     }
   }
@@ -209,6 +210,7 @@ object BufferedValue extends Transformer[BufferedValue] {
     override def equals(that: Any): Boolean = that match {
       case NumLong(otherL) => this.d == otherL.toDouble
       case NumDouble(otherD) => this.d == otherD
+      case other: AnyNum => this.value == other.value
       case _ => super.equals(that)
     }
   }

--- a/weejson/src/main/scala/com/rallyhealth/weejson/v1/BufferedValue.scala
+++ b/weejson/src/main/scala/com/rallyhealth/weejson/v1/BufferedValue.scala
@@ -173,6 +173,9 @@ object BufferedValue extends Transformer[BufferedValue] {
           }
       case _ => super.equals(that)
     }
+
+    // expensive but reliable
+    override def hashCode(): Int = this.value0.sortBy(_._1).hashCode()
   }
 
   case class Arr(value: BufferedValue*) extends BufferedValue {
@@ -191,6 +194,9 @@ object BufferedValue extends Transformer[BufferedValue] {
       case other: AnyNum => this.value == other.value
       case _ => super.equals(that)
     }
+
+    // expensive but reliable
+    override def hashCode(): Int = this.value.hashCode()
   }
 
   case class NumLong(l: Long) extends AnyNum {
@@ -202,6 +208,9 @@ object BufferedValue extends Transformer[BufferedValue] {
       case other: AnyNum => this.value == other.value
       case _ => super.equals(that)
     }
+
+    // expensive but reliable
+    override def hashCode(): Int = this.value.hashCode()
   }
 
   case class NumDouble(d: Double) extends AnyNum {
@@ -213,6 +222,9 @@ object BufferedValue extends Transformer[BufferedValue] {
       case other: AnyNum => this.value == other.value
       case _ => super.equals(that)
     }
+
+    // expensive but reliable
+    override def hashCode(): Int = this.value.hashCode()
   }
 
   object AnyNum {
@@ -233,10 +245,13 @@ object BufferedValue extends Transformer[BufferedValue] {
 
   case class Binary(b: Array[Byte]) extends BufferedValue {
     override def toString: String = s"Binary(${b.toSeq})"
+
     override def equals(that: Any): Boolean = that match {
       case Binary(thatB) => Arrays.equals(this.b, thatB)
       case _ => super.equals(that)
     }
+
+    override def hashCode(): Int = Arrays.hashCode(this.b)
   }
 
   case class Ext(tag: Byte, b: Array[Byte]) extends BufferedValue {
@@ -247,6 +262,9 @@ object BufferedValue extends Transformer[BufferedValue] {
         this.tag == thatTag && Arrays.equals(this.b, thatB)
       case _ => super.equals(that)
     }
+
+    // collision when only tag is different (rare)
+    override def hashCode(): Int = Arrays.hashCode(this.b)
   }
 
   case class Timestamp(i: Instant) extends BufferedValue

--- a/weejson/src/main/scala/com/rallyhealth/weejson/v1/BufferedValue.scala
+++ b/weejson/src/main/scala/com/rallyhealth/weejson/v1/BufferedValue.scala
@@ -194,7 +194,7 @@ object BufferedValue extends Transformer[BufferedValue] {
       case NumLong(l) => value == l.value
       case NumDouble(d) =>
         val thisD = value.toDouble // may chop precision or go infinite
-        if (thisD.isFinite) thisD == d else value == d.value
+        if (thisD.isInfinite) value == d.value else thisD == d
       case other: Num => value == other.value
       case _ => super.equals(that)
     }
@@ -230,7 +230,7 @@ object BufferedValue extends Transformer[BufferedValue] {
       case NumDouble(otherD) => this.d == otherD
       case other: Num =>
         val otherD = other.value.toDouble // may chop precision or go infinite
-        if (otherD.isFinite) this.d == otherD else this.value == other.value
+        if (otherD.isInfinite) this.value == other.value else this.d == otherD
       case _ => super.equals(that)
     }
 

--- a/weejson/src/main/scala/com/rallyhealth/weejson/v1/BufferedValue.scala
+++ b/weejson/src/main/scala/com/rallyhealth/weejson/v1/BufferedValue.scala
@@ -195,8 +195,8 @@ object BufferedValue extends Transformer[BufferedValue] {
       case _ => super.equals(that)
     }
 
-    // expensive but reliable
-    override def hashCode(): Int = this.value.hashCode()
+    // all values outside of Double range hash to the same value
+    override def hashCode(): Int = this.value.toDouble.hashCode()
   }
 
   case class NumLong(l: Long) extends AnyNum {
@@ -209,8 +209,7 @@ object BufferedValue extends Transformer[BufferedValue] {
       case _ => super.equals(that)
     }
 
-    // expensive but reliable
-    override def hashCode(): Int = this.value.hashCode()
+    override def hashCode(): Int = this.l.toDouble.hashCode()
   }
 
   case class NumDouble(d: Double) extends AnyNum {
@@ -223,8 +222,7 @@ object BufferedValue extends Transformer[BufferedValue] {
       case _ => super.equals(that)
     }
 
-    // expensive but reliable
-    override def hashCode(): Int = this.value.hashCode()
+    override def hashCode(): Int = this.d.hashCode()
   }
 
   object AnyNum {

--- a/weejson/src/main/scala/com/rallyhealth/weejson/v1/BufferedValue.scala
+++ b/weejson/src/main/scala/com/rallyhealth/weejson/v1/BufferedValue.scala
@@ -232,7 +232,7 @@ object BufferedValue extends Transformer[BufferedValue] {
   }
 
   case class Binary(b: Array[Byte]) extends BufferedValue {
-
+    override def toString: String = s"Binary(${b.toSeq})"
     override def equals(that: Any): Boolean = that match {
       case Binary(thatB) => Arrays.equals(this.b, thatB)
       case _ => super.equals(that)
@@ -240,6 +240,7 @@ object BufferedValue extends Transformer[BufferedValue] {
   }
 
   case class Ext(tag: Byte, b: Array[Byte]) extends BufferedValue {
+    override def toString: String = s"Ext($tag, ${b.toSeq})"
 
     override def equals(that: Any): Boolean = that match {
       case Ext(thatTag, thatB) =>

--- a/weejson/src/main/scala/com/rallyhealth/weejson/v1/BufferedValue.scala
+++ b/weejson/src/main/scala/com/rallyhealth/weejson/v1/BufferedValue.scala
@@ -188,13 +188,11 @@ object BufferedValue extends Transformer[BufferedValue] {
   }
 
   case class Num(s: String, decIndex: Int, expIndex: Int) extends AnyNum {
-    override lazy val value: BigDecimal = BigDecimal(s)
+    override def value: BigDecimal = BigDecimal(s)
 
     override def equals(that: Any): Boolean = that match {
-      case NumLong(l) => value == l.value
-      case NumDouble(d) =>
-        val thisD = value.toDouble // may chop precision or go infinite
-        if (thisD.isInfinite) value == d.value else thisD == d
+      case NumLong(otherL) => value == otherL
+      case NumDouble(otherD) => value.toDouble == otherD
       case other: Num => value == other.value
       case _ => super.equals(that)
     }
@@ -214,8 +212,8 @@ object BufferedValue extends Transformer[BufferedValue] {
 
     override def equals(that: Any): Boolean = that match {
       case NumLong(otherL) => this.l == otherL
-      case NumDouble(otherD) => this.l.toDouble == otherD
-      case other: Num => this.l.value == other.value
+      case NumDouble(otherD) => this.l == otherD
+      case other: Num => this.l == other.value
       case _ => super.equals(that)
     }
 
@@ -228,9 +226,7 @@ object BufferedValue extends Transformer[BufferedValue] {
     override def equals(that: Any): Boolean = that match {
       case NumLong(otherL) => this.d == otherL.toDouble
       case NumDouble(otherD) => this.d == otherD
-      case other: Num =>
-        val otherD = other.value.toDouble // may chop precision or go infinite
-        if (otherD.isInfinite) this.value == other.value else this.d == otherD
+      case other: Num => this.d == other.value.toDouble
       case _ => super.equals(that)
     }
 

--- a/weejson/src/test/scala/com/rallyhealth/weejson/v1/BufferedValueSpec.scala
+++ b/weejson/src/test/scala/com/rallyhealth/weejson/v1/BufferedValueSpec.scala
@@ -26,7 +26,7 @@ class BufferedValueSpec
     }
   }
 
-  property("roundtrip: Visitor with object attributes shuffled") {
+  property("roundtrip: Visitor with object shuffling") {
     forAll { (value: BufferedValue) =>
       shuffleObjs(value.transform(BufferedValue.Builder)) should ===(value)
     }

--- a/weejson/src/test/scala/com/rallyhealth/weejson/v1/BufferedValueSpec.scala
+++ b/weejson/src/test/scala/com/rallyhealth/weejson/v1/BufferedValueSpec.scala
@@ -61,12 +61,12 @@ class BufferedValueSpec
   property("numeric equivalence: BigDecimal range/precision") {
     forAll { (value: BigDecimal) =>
       assert(
-        if (value.toDouble.isFinite) equalsAndHashCode(
-          () => BufferedValue.Num(value.toString, -1, -1),
-          () => BufferedValue.NumDouble(value.toDouble)
+        if (value.toDouble.isInfinite) equalsAndHashCode(
+          () => BufferedValue.Num(value.toString, -1, -1)
         )
         else equalsAndHashCode(
-          () => BufferedValue.Num(value.toString, -1, -1)
+          () => BufferedValue.Num(value.toString, -1, -1),
+          () => BufferedValue.NumDouble(value.toDouble)
         )
       )
     }

--- a/weejson/src/test/scala/com/rallyhealth/weejson/v1/BufferedValueSpec.scala
+++ b/weejson/src/test/scala/com/rallyhealth/weejson/v1/BufferedValueSpec.scala
@@ -3,16 +3,16 @@ package com.rallyhealth.weejson.v1
 import com.rallyhealth.weejson.v1.jackson.{FromJson, ToJson}
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.propspec.AnyPropSpec
+import org.scalatest.propspec.AnyPropSpecLike
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import scala.util.Random
 
 class BufferedValueSpec
-    extends AnyPropSpec
+    extends GenBufferedValue(jsonReversible = false)
+    with AnyPropSpecLike
     with Matchers
     with ScalaCheckPropertyChecks
-    with GenBufferedValue
     with TypeCheckedTripleEquals {
   import BufferedValueOps._
 

--- a/weejson/src/test/scala/com/rallyhealth/weejson/v1/GenBufferedValue.scala
+++ b/weejson/src/test/scala/com/rallyhealth/weejson/v1/GenBufferedValue.scala
@@ -73,8 +73,10 @@ trait GenBufferedValue {
     }
   }
 
+  // can't use Arbitrary.arbitrary[Instant] because it isn't available in Scala 2.11 libs :'(
   implicit val arbTimestamp: Arbitrary[Timestamp] = Arbitrary {
-    Arbitrary.arbitrary[Instant](Arbitrary.arbInstant).map(Timestamp(_))
+    Gen.chooseNum[Long](Long.MinValue, Long.MaxValue)
+      .map(ms => Timestamp(Instant.ofEpochMilli(ms)))
   }
 
   implicit val shrinkValue: Shrink[BufferedValue] = Shrink[BufferedValue] { bv =>

--- a/weejson/src/test/scala/com/rallyhealth/weejson/v1/GenBufferedValue.scala
+++ b/weejson/src/test/scala/com/rallyhealth/weejson/v1/GenBufferedValue.scala
@@ -74,7 +74,7 @@ trait GenBufferedValue {
   }
 
   implicit val arbTimestamp: Arbitrary[Timestamp] = Arbitrary {
-    Arbitrary.arbitrary[Instant].map(Timestamp(_))
+    Gen.choose(Instant.MIN, Instant.MAX).map(Timestamp(_))
   }
 
   implicit val shrinkValue: Shrink[BufferedValue] = Shrink[BufferedValue] { bv =>

--- a/weejson/src/test/scala/com/rallyhealth/weejson/v1/GenBufferedValue.scala
+++ b/weejson/src/test/scala/com/rallyhealth/weejson/v1/GenBufferedValue.scala
@@ -74,7 +74,7 @@ trait GenBufferedValue {
   }
 
   implicit val arbTimestamp: Arbitrary[Timestamp] = Arbitrary {
-    Gen.choose(Instant.MIN, Instant.MAX).map(Timestamp(_))
+    Arbitrary.arbitrary[Instant](Arbitrary.arbInstant).map(Timestamp(_))
   }
 
   implicit val shrinkValue: Shrink[BufferedValue] = Shrink[BufferedValue] { bv =>

--- a/weejson/src/test/scala/com/rallyhealth/weejson/v1/GenBufferedValue.scala
+++ b/weejson/src/test/scala/com/rallyhealth/weejson/v1/GenBufferedValue.scala
@@ -64,17 +64,17 @@ trait GenBufferedValue {
   }
 
   implicit val arbBinary: Arbitrary[Binary] = Arbitrary {
-    Arbitrary.arbitrary[Array[Byte]].map(b => Binary(b))
+    Arbitrary.arbitrary[Array[Byte]].map(Binary(_))
   }
 
   implicit val arbExt: Arbitrary[Ext] = Arbitrary {
-    Gen.choose[Byte](Byte.MinValue, Byte.MaxValue).flatMap { tag =>
-      Arbitrary.arbitrary[Array[Byte]].map(b => Ext(tag, b))
+    Arbitrary.arbitrary[Byte].flatMap { tag =>
+      Arbitrary.arbitrary[Array[Byte]].map(Ext(tag, _))
     }
   }
 
   implicit val arbTimestamp: Arbitrary[Timestamp] = Arbitrary {
-    Gen.choose[Instant](Instant.MIN, Instant.MAX).map(Timestamp(_))
+    Arbitrary.arbitrary[Instant].map(Timestamp(_))
   }
 
   implicit val shrinkValue: Shrink[BufferedValue] = Shrink[BufferedValue] { bv =>

--- a/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/ParserSpec.scala
+++ b/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/ParserSpec.scala
@@ -5,7 +5,7 @@ import com.rallyhealth.weejson.v1.jackson.{FromJson, ToJson, ToPrettyJson}
 import com.rallyhealth.weejson.v1.{BufferedValue, GenBufferedValue}
 import com.rallyhealth.weepickle.v1.core.{FromInput, NoOpVisitor}
 import org.scalactic.TypeCheckedTripleEquals
-import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.freespec.AnyFreeSpecLike
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import java.io.{ByteArrayInputStream, File, StringReader}
@@ -15,9 +15,9 @@ import scala.language.{existentials, implicitConversions}
 import scala.util.Try
 
 abstract class ParserSpec(parse: Array[Byte] => FromInput, depthLimit: Int = 100)
-  extends AnyFreeSpec
+  extends GenBufferedValue(jsonReversible = true)
+    with AnyFreeSpecLike
     with ScalaCheckPropertyChecks
-    with GenBufferedValue
     with TypeCheckedTripleEquals {
 
   import com.rallyhealth.weejson.v1.BufferedValue._


### PR DESCRIPTION
Resolve issues with byte array comparisons in `Binary` and `Ext`. Resolve attribute order sensitivity in `Obj`. Allow equality across `AnyNum` subtypes, only converting to `BigDecimal` when needed. Enhance property tests to deal with all subtypes and test `Obj` attribute shuffles.