### PR TITLE
FromJson(String, etc.).transform() replayable

### DIFF
--- a/project/WeePicklePlugin.scala
+++ b/project/WeePicklePlugin.scala
@@ -127,6 +127,10 @@ object WeePicklePlugin extends AutoPlugin {
         case _ => Nil
       }
     },
+    Test / scalacOptions := {
+      // FromJsonTests.scala:34:3 "A pure expression does nothing in statement position"
+      (Test / scalacOptions).value.filterNot(_ == "-Xfatal-warnings")
+    },
     testFrameworks += new TestFramework("utest.runner.Framework"),
   )
 }

--- a/weejson-jackson/src/test/scala/com/rallyhealth/weejson/v1/jackson/FromJsonTests.scala
+++ b/weejson-jackson/src/test/scala/com/rallyhealth/weejson/v1/jackson/FromJsonTests.scala
@@ -1,0 +1,35 @@
+package com.rallyhealth.weejson.v1.jackson
+
+import com.rallyhealth.weepickle.v1.core.FromInput
+import utest._
+
+import java.io.{ByteArrayInputStream, StringReader}
+import java.nio.file.{Files, Path}
+
+object FromJsonTests extends TestSuite {
+  override val tests = Tests {
+    test("replay") {
+      test("FromJson(String)")(replay(FromJson("true")))
+      test("FromJson(Array[Byte])")(replay(FromJson("true".getBytes)))
+      test("FromJson(Path)")(replay(FromJson(path)))
+      test("FromJson(File)")(replay(FromJson(path.toFile)))
+
+      def replay(fromInput: FromInput) = {
+        fromInput.transform(TrueVisitor) ==> true
+        fromInput.transform(TrueVisitor) ==> true
+        fromInput.transform(TrueVisitor) ==> true
+      }
+      def path: Path = Files.write(Files.createTempFile("", ".json"), "true".getBytes)
+    }
+
+    test("no replay") {
+      test("FromJson(InputStream)")(noReplay(FromJson(new ByteArrayInputStream("true".getBytes))))
+      test("FromJson(Reader)")(noReplay(FromJson(new StringReader("true"))))
+
+      def noReplay(fromInput: FromInput) = {
+        fromInput.transform(TrueVisitor) ==> true
+        intercept[Exception](fromInput.transform(TrueVisitor))
+      }
+    }
+  }
+}

--- a/weejson-jackson/src/test/scala/com/rallyhealth/weejson/v1/jackson/TrueVisitor.scala
+++ b/weejson-jackson/src/test/scala/com/rallyhealth/weejson/v1/jackson/TrueVisitor.scala
@@ -1,0 +1,10 @@
+package com.rallyhealth.weejson.v1.jackson
+
+import com.rallyhealth.weepickle.v1.core.SimpleVisitor
+
+object TrueVisitor extends SimpleVisitor[Boolean, Boolean] {
+
+  override def expectedMsg: String = "expected true"
+
+  override def visitTrue(): Boolean = true
+}


### PR DESCRIPTION
Allow calling `.transform()` on a `FromJson`, `FromYaml`, `FromXml`, etc. that was created with a replayable input type (`String`, `Array[Byte]`, `File`, etc.). Otherwise, throws a clearer exception if the `JsonParser` has already been closed.

Fixes #108. @marekklis