### PR TITLE
Fix None macro scoping

### DIFF
--- a/weepickle-implicits/src/main/scala-2/com/rallyhealth/weepickle/v1/implicits/MacroImplicits.scala
+++ b/weepickle-implicits/src/main/scala-2/com/rallyhealth/weepickle/v1/implicits/MacroImplicits.scala
@@ -168,7 +168,7 @@ private object MacroImplicits {
         if (isParamWithDefault) {
           Some(q"$companion.$defaultName")
         } else {
-          if (assumeDefaultNone) Some(q"${TermName("scala.None")}")
+          if (assumeDefaultNone) Some(q"scala.None")
           else None
         }
       }

--- a/weepickle-implicits/src/main/scala-2/com/rallyhealth/weepickle/v1/implicits/MacroImplicits.scala
+++ b/weepickle-implicits/src/main/scala-2/com/rallyhealth/weepickle/v1/implicits/MacroImplicits.scala
@@ -168,7 +168,7 @@ private object MacroImplicits {
         if (isParamWithDefault) {
           Some(q"$companion.$defaultName")
         } else {
-          if (assumeDefaultNone) Some(q"${TermName("None")}")
+          if (assumeDefaultNone) Some(q"${TermName("scala.None")}")
           else None
         }
       }

--- a/weepickle-implicits/src/main/scala-3/com/rallyhealth/weepickle/v1/implicits/macros.scala
+++ b/weepickle-implicits/src/main/scala-3/com/rallyhealth/weepickle/v1/implicits/macros.scala
@@ -56,7 +56,7 @@ def getDefaultParamsImpl[T](using Quotes, Type[T]): Expr[String => Option[() => 
     val namesExpr: Expr[List[String]] = Expr.ofList((names ++ assumeDefaultNoneNames).map(Expr(_)))
     val identsExpr: Expr[List[() => AnyRef]] = Expr.ofList(
       idents.map(_.asExpr).map(i => '{ () => $i.asInstanceOf[AnyRef] }) ++
-      assumeDefaultNoneNames.map(_ => '{ () => None })
+      assumeDefaultNoneNames.map(_ => '{ () => scala.None })
     )
 
     '{ $namesExpr.zip($identsExpr).toMap.get }

--- a/weepickle-implicits/src/main/scala-3/com/rallyhealth/weepickle/v1/implicits/macros.scala
+++ b/weepickle-implicits/src/main/scala-3/com/rallyhealth/weepickle/v1/implicits/macros.scala
@@ -56,7 +56,7 @@ def getDefaultParamsImpl[T](using Quotes, Type[T]): Expr[String => Option[() => 
     val namesExpr: Expr[List[String]] = Expr.ofList((names ++ assumeDefaultNoneNames).map(Expr(_)))
     val identsExpr: Expr[List[() => AnyRef]] = Expr.ofList(
       idents.map(_.asExpr).map(i => '{ () => $i.asInstanceOf[AnyRef] }) ++
-      assumeDefaultNoneNames.map(_ => '{ () => scala.None })
+      assumeDefaultNoneNames.map(_ => '{ () => None })
     )
 
     '{ $namesExpr.zip($identsExpr).toMap.get }

--- a/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/example/ExampleTests.scala
+++ b/weepickle-tests/src/test/scala/com/rallyhealth/weepickle/v1/example/ExampleTests.scala
@@ -71,6 +71,11 @@ case class Maybe2(@dropDefault i: Option[Int] = None)
 object Maybe2 {
   implicit val rw: RW[Maybe2] = WeePickle.macroFromTo[Maybe2]
 }
+case class Maybe3(foo: Int, bar: Option[Int])
+object Maybe3 {
+  val None = "None"
+  implicit val rw: RW[Maybe3] = WeePickle.macroFromTo[Maybe3]
+}
 object Keyed {
   case class KeyBar(@com.rallyhealth.weepickle.v1.implicits.key("hehehe") kekeke: Int)
   object KeyBar {
@@ -216,6 +221,9 @@ object ExampleTests extends TestSuite {
         FromJson("""{"i":42}""").transform(ToScala[Maybe1]) ==> Maybe1(Some(42))
 
         FromScala(Maybe2(None)).transform(ToJson.string) ==> """{}"""
+      }
+      test("""options default to scala.None not "None"""") {
+        FromJson("""{"foo": 123}""").transform(ToScala[Maybe3]) ==> Maybe3(123, scala.None)
       }
       test("tuples") {
         FromScala((1, "omg")).transform(ToJson.string) ==> """[1,"omg"]"""


### PR DESCRIPTION
An attempt to solve this bug:
![image](https://user-images.githubusercontent.com/14933465/168856397-0a1160ad-dc66-422c-ae15-f531bd9d349b.png)

worksheet code:
```
import com.rallyhealth.weejson.v1.jackson.FromJson
import com.rallyhealth.weepickle.v1.WeePickle._

object BreakMe  {
  val None = 1
}
import BreakMe._

case class Foo(
  x: Int,
  y: Option[String]
)

object Foo {
  implicit val fromTo = macroFromTo[Foo]
}


FromJson("""{"x": 123}""").transform(ToScala[Foo])
```