### PR TITLE
Play 3.0 compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -177,12 +177,13 @@ lazy val `weejson-play-base` = (project in file("weejson-play"))
 
 def playProject(playVersion: String, scalaVersions: Seq[String]) = {
   val playString = playVersion.split('.').take(2).mkString("play", "", "")
+  val playOrg =
+    if (playVersion.startsWith("3")) "org.playframework"
+    else "com.typesafe.play"
   Project(s"weejson-$playString", file(s"weejson-$playString"))
     .dependsOn(weepickle)
     .settings(
-      libraryDependencies ++= Seq(
-        "com.typesafe.play" %% "play-json" % playVersion,
-      ),
+      libraryDependencies += playOrg %% "play-json" % playVersion,
       Compile / unmanagedSourceDirectories ++= (`weejson-play-base` / Compile / unmanagedSourceDirectories).value,
       Test / unmanagedSourceDirectories ++= (`weejson-play-base` / Test / unmanagedSourceDirectories).value,
       crossScalaVersions := scalaVersions,
@@ -201,14 +202,10 @@ lazy val `weejson-play28` = playProject("2.8.2", Seq(scala213))
 // and no version of Play actually uses play-json 2.9
 lazy val `weejson-play29` = playProject("2.9.4", Seq(scala213))
 
-lazy val `weejson-play210` = playProject("2.10.1", Seq(scala213, scala3)).settings(
-  mimaPreviousArtifacts := {
-    if (VersionNumber(version.value).matchesSemVer(SemanticSelector("<1.9.0")) && scalaBinaryVersion.value == "2.13")
-      Set.empty // TODO: remove once there's a previous Scala 2.13 artifact
-    else
-      mimaPreviousArtifacts.value
-  }
-)
+lazy val `weejson-play210` = playProject("2.10.2", Seq(scala213, scala3))
+
+lazy val `weejson-play30` = playProject("3.0.0", Seq(scala213, scala3))
+  .settings(mimaPreviousArtifacts := Set.empty) // TODO: remove once there's a previous artifact
 
 lazy val `weejson-upickle` = project
   .dependsOn(weepickle)


### PR DESCRIPTION
## Proposed changes

Add Scala 2.13 and Scala 3 artifacts for the play-json version compatible with Play 3.0. (Play 3.0 uses play-json 3.0.)

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/rallyhealth/weePickle/blob/v1/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

No new tests, just a new set project that runs existing shared weejson tests.